### PR TITLE
:sparkles: feature: choose the audio_file from `yutto-uiya` module.

### DIFF
--- a/src/lab/_session_keys.py
+++ b/src/lab/_session_keys.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lab._typing import AudioSessionStateKeys
+
+# 用于自动补全，防止输错 keys 导致的未初始化（这点真的挺ex的）
+audio_keys: AudioSessionStateKeys = {
+    "audio_name": "audio_name",
+    "audio_file": "audio_file",
+    "use_upload": "use_upload",
+    "use_example": "use_example",
+    "use_bilibili": "use_bilibili",
+    "response_with_timestamp": "response_with_timestamp",
+    "text_result": "text_result",
+    "preview_srt_file": "preview_srt_file",
+    "guide": "guide",
+    "readme": "readme",
+    "welcome": "welcome",
+    "save": "save",
+    "upload": "upload",
+    "cut_line": "cut_line",
+    "output_type": "output_type",
+    "combine_line": "combine_line",
+    "subtitle_speed": "subtitle_speed",
+    "max_sentence_length": "max_sentence_length",
+}

--- a/src/lab/_typing.py
+++ b/src/lab/_typing.py
@@ -98,3 +98,36 @@ class DebugMessage(TypedDict):
     segmented_text: list[str]
     total_words_num: int
     total_ts_num: int
+
+
+class AudioSessionStateKeys(TypedDict):
+    """audio.py 中用到的 st.session_state 的 key_names"""
+
+    audio_name: str  # 音频文件名(包含后缀), 用来判断是否需要 FileToWav
+    audio_file: str  # 音频文件的绝对路径
+
+    # ======= 音频文件获取方式.
+    use_upload: str  # 是否使用上传的音频
+    use_example: str  # 是否使用示例音频
+    use_bilibili: str  # 是否使用 bilibili 模块下载的音频
+
+    # ======= 音频识别
+    response_with_timestamp: str  # 带时间戳的识别结果
+    text_result: str  # 不带时间戳的识别结果, only text
+
+    # ======= 界面展示
+    preview_srt_file: str  # 实时读取并且预览的 srt 文件 Path
+
+    # ======= 信息提示
+    readme: str  # guide
+    welcome: str  # welcome
+    save: str  # 保存成功后提示信息
+    upload: str  # 上传成功后提示信息
+    guide: str  # guide
+
+    # ======= 配置文件
+    output_type: str  # 输出文件类型
+    subtitle_speed: str  # 字幕速度
+    cut_line: str
+    combine_line: str
+    max_sentence_length: str  # 最大句子长度

--- a/src/lab/pages/dialogs/audio.py
+++ b/src/lab/pages/dialogs/audio.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import streamlit as st
+from uiya.utils.config import UiyaSetting, load_settings_file as load_uiya_settings_file
+
+from lab._dataclass import RootAbsDir
+from lab._session_keys import audio_keys
+from lab.utils.config import load_settings_file
+
+root_settings = load_settings_file("root.toml", setting=RootAbsDir)
+uiya_settings = load_uiya_settings_file("uiya.toml", setting=UiyaSetting)
+ROOT_DIR = root_settings.root_dir
+
+
+# 函数内部应该避免以 st.session_state 为判断条件，除非，它是一个完整模块，从初始化到结束都在这个模块中。
+# 但是 dialog 不会是一个完整模块
+@st.dialog("使用提示")
+def AudioReadme():
+    st.markdown(
+        """
+    ## 欢迎使用 AI全自动音频翻译 功能！
+    请务必根据您的需求及时调整设置，以提高翻译的准确性和效率。
+    更多参考资源：
+    - 📘 [相关教程还没出噢](https://xnnehang.top/)
+
+    """
+    )
+    st.markdown("")
+    if st.button(
+        "**我已知晓&nbsp;&nbsp;&nbsp;本次不再弹出**",
+        type="primary",
+        use_container_width=True,
+        key="guide",
+    ):
+        st.session_state[audio_keys["welcome"]] = True
+        st.rerun()
+
+
+@st.dialog("选择待处理音频")
+def upload_audio():
+    st.markdown("## 方式一:上传音频文件")
+    st.markdown("在这里上传您需要处理的音频文件，该模块一次只能处理一个，多个会互相覆盖。")
+    st.caption(
+        """该服务用 frp 内网穿透,你看到的上传进度条只是上传到服务器,服务器还得发到我的电脑,所以会卡100%，所以请上传小文件试试水(<10MB)."""
+    )
+    # st.caption(
+    #     """另外，如果有对德国(欧洲地区)速度较快(下载速度可以达到超过20MB/s,目前大概只有10MB/s)的代理也可以向我推荐。"""
+    # )
+    st.markdown("")
+
+    audio_file = st.file_uploader(
+        "上传您的音频文件",
+        type=["mp3", "mpga", "m4a", "wav"],
+        label_visibility="collapsed",
+        accept_multiple_files=False,
+    )
+    st.markdown("")
+    if st.button("**点击上传**", use_container_width=True, type="primary"):
+        if audio_file is None:
+            st.toast("请先上传文件", icon=":material/error:")
+            pass
+        else:
+            st.session_state[audio_keys["audio_file"]] = audio_file
+            st.session_state[audio_keys["upload"]] = True
+            st.session_state[audio_keys["use_upload"]] = True
+            st.session_state[audio_keys["use_bilibili"]] = False
+            st.session_state[audio_keys["use_example"]] = False
+            st.rerun()
+
+    st.markdown("## 方式二: 使用示例文件/无需等待上传")
+    st.caption("example1: 截取了 example2 的第一句歌词， 我用来跑 CI/CD 的。")
+    st.caption("example2: [【AI巴老师】难道看我失魂落魄,你竟然心动](https://www.bilibili.com/video/BV1314y1k73r/)")
+    st.markdown("")
+
+    audio_name = st.selectbox(
+        "选择示例文件",
+        [
+            "example1.wav",
+            "example2.m4a",
+        ],
+    )
+    if st.button("**使用示例文件**", use_container_width=True, type="primary"):
+        if audio_name == "example1.wav":
+            st.session_state[audio_keys["audio_file"]] = "examples/example1.wav"
+            st.session_state[audio_keys["audio_name"]] = audio_name
+            st.session_state[audio_keys["use_example"]] = True
+            st.session_state[audio_keys["use_bilibili"]] = False
+            st.session_state[audio_keys["use_upload"]] = False
+            st.rerun()
+        elif audio_name == "example2.m4a":
+            st.session_state[audio_keys["audio_file"]] = "examples/example2.m4a"
+            st.session_state[audio_keys["audio_name"]] = audio_name
+            st.session_state[audio_keys["use_example"]] = True
+            st.session_state[audio_keys["use_bilibili"]] = False
+            st.session_state[audio_keys["use_upload"]] = False
+            st.rerun()
+
+    st.markdown("## 方式三: 从 `b站视频下载` 模块导入")
+    st.caption(
+        """
+        在 `b站视频下载` 模块中单独勾选 `音频` 项然后下载，可以在这里访问。
+        """
+    )
+    # 找出所有的音频文件
+    audio_paths_list: list[str] = []
+    for root, _, files in os.walk(Path(ROOT_DIR) / "downloads"):
+        for file in files:
+            if file.endswith(".m4s") or file.endswith(".m4a") or file.endswith(".mp3"):
+                audio_paths_list.append(str(Path(root) / file))
+    audio_name_path_dict: dict[str, str] = {}
+    for audio_path in audio_paths_list:
+        audio_name = Path(audio_path).name
+        audio_name_path_dict[audio_name] = audio_path
+    if audio_paths_list:
+        audio_name = st.selectbox(
+            "选择音频文件",
+            [Path(audio_path).name for audio_path in audio_paths_list],
+            label_visibility="collapsed",
+        )
+        st.markdown("")
+    else:
+        audio_name = ""
+        st.info(
+            "##### 音频文件区域 \n\n&nbsp;\n\n**没有找到音频文件,请在 `b站视频下载` 模块中单独勾选 `音频` 项然后下载。**\n\n&nbsp;\n\n&nbsp;",
+            icon=":material/view_in_ar:",
+        )
+        st.markdown("")
+
+    if st.button("选择该音频文件", use_container_width=True, type="primary"):
+        if audio_name:
+            st.session_state[audio_keys["audio_name"]] = audio_name
+            st.session_state[audio_keys["audio_file"]] = audio_name_path_dict[audio_name]
+            st.session_state[audio_keys["use_bilibili"]] = True
+            st.session_state[audio_keys["use_example"]] = False
+            st.session_state[audio_keys["use_upload"]] = False
+            st.rerun()
+        else:
+            st.toast("请先选择音频文件", icon=":material/error:")
+            st.stop()

--- a/src/lab/pages/project/audio.py
+++ b/src/lab/pages/project/audio.py
@@ -192,7 +192,7 @@ with tab1:
                     cache_dir = st.session_state.cache_dir
                     cache_dir.mkdir(parents=True, exist_ok=True)
                     shutil.copy(
-                        Path(f"tests/{st.session_state.audio_name}"),
+                        Path(f"examples/{st.session_state.audio_name}"),
                         cache_dir / st.session_state.audio_name,
                     )
                     if audio_last_name != "wav":
@@ -286,9 +286,11 @@ with tab1:
             @st.dialog("上传音频文件 / 选择示例文件")
             def upload_audio():
                 st.markdown("在这里上传您需要处理的音频文件，该模块一次只能处理一个，多个会互相覆盖。")
-                st.markdown("""暂时受限于我家下行带宽(90M),建议上传小文件,mp3,m4a 都可以。wav 太大了。""")
                 st.caption(
-                    """该服务用 frp 内网穿透，你看到的上传进度条只是上传到服务器，服务器还得发到我的电脑，所以会卡100%（等待电脑下载到本地，超级久），所以请上传小文件试试水（<10MB）！！！"""
+                    """该服务用 frp 内网穿透,你看到的上传进度条只是上传到服务器,服务器还得发到我的电脑,所以会卡100%，所以请上传小文件试试水(<10MB)."""
+                )
+                st.caption(
+                    """另外，如果有对德国(欧洲地区)速度较快(下载速度可以达到超过20MB/s,目前大概只有10MB/s)的代理也可以向我推荐。"""
                 )
                 st.markdown("")
 
@@ -310,37 +312,28 @@ with tab1:
                         st.rerun()
 
                 st.markdown("**PS:** 因为卡 100% 真的很影响体验，这里提供了示例文件（都存在我的电脑中，不需要上传）。")
-                st.caption("example1: [华容道迷宫 | 《20 Small Mazes》](https://www.bilibili.com/video/BV1Xzk3YPEd9)")
+                st.caption("example1: 截取了 example2 的第一句歌词， 我用来跑 CI/CD 的。")
                 st.caption(
-                    "example2: [【AI巴老师】难道看我失魂落魄，你竟然心动](https://www.bilibili.com/video/BV1314y1k73r/)"
+                    "example2: [【AI巴老师】难道看我失魂落魄,你竟然心动](https://www.bilibili.com/video/BV1314y1k73r/)"
                 )
-                st.caption("example3: AI生成的一个长音频,用于上行速度影响测试。")
                 st.markdown("")
-                st.caption("也欢迎你通知我你要补充的示例文件。")
 
                 select_file = st.selectbox(
                     "选择示例文件",
                     [
                         "example1.wav",
                         "example2.m4a",
-                        "example3.mp3",
                     ],
                 )
                 if st.button("**使用示例文件**", use_container_width=True, type="primary"):
                     if select_file == "example1.wav":
-                        st.session_state.audio_file = "tests/example1.wav"
+                        st.session_state.audio_file = "examples/example1.wav"
                         st.session_state.selected_file = select_file
                         st.session_state.use_example = True
                         st.session_state.upload = True
                         st.rerun()
                     elif select_file == "example2.m4a":
-                        st.session_state.audio_file = "tests/example2.m4a"
-                        st.session_state.selected_file = select_file
-                        st.session_state.use_example = True
-                        st.session_state.upload = True
-                        st.rerun()
-                    elif select_file == "example3.mp3":
-                        st.session_state.audio_file = "tests/example3.mp3"
+                        st.session_state.audio_file = "examples/example2.m4a"
                         st.session_state.selected_file = select_file
                         st.session_state.use_example = True
                         st.session_state.upload = True

--- a/src/lab/pages/project/audio.py
+++ b/src/lab/pages/project/audio.py
@@ -7,10 +7,12 @@ from pathlib import Path
 import streamlit as st
 
 from lab._dataclass import AudioSettings, RunnerSettings
+from lab._session_keys import audio_keys
 from lab.BasicRunner.combiner import combine_sentences
 from lab.BasicRunner.converter import convert_asr_response_to_sentences
 from lab.BasicRunner.cutter import cut_sentences
 from lab.BasicRunner.extractor import save_only_text_from_response
+from lab.pages.dialogs.audio import AudioReadme, upload_audio
 from lab.styles.global_style import style
 from lab.utils.config import get_setting_title, load_settings_file, write_settings_file
 from lab.utils.FFmpegHelper import file_to_wav
@@ -21,82 +23,72 @@ from lab.utils.public import (
 )
 from lab.utils.SrtHelper import write_srt_from_sentences
 
+# ============== 0.加载配置，配置字体
+
 style()
 settings: RunnerSettings = load_settings_file("global.toml", setting=RunnerSettings)
 audio_settings: AudioSettings = load_settings_file("audio.toml", setting=AudioSettings)
 fonts = read_font_data()
-
-
 if not fonts:
     raise FileNotFoundError("Font data not found!")
 
-guide = st.session_state.get("guide", audio_settings.guide)
-output_type = st.session_state.get("output_type", audio_settings.output_type)
-subtitle_speed = st.session_state.get("subtitle_speed", audio_settings.subtitle_speed)
-cut_line = st.session_state.get("cut_line", settings.cut_line)
-combine_line = st.session_state.get("combine_line", settings.combine_line)
-max_sentence_length = st.session_state.get("max_sentence_length", settings.max_sentence_length)
+# ============== 1.初始化持久化参数
 
+# 参数说明参见 _session_keys.py
 
-@st.dialog("使用提示")
-def AudioReadme():
-    st.markdown(
-        """
-    ## 欢迎使用 AI全自动音频翻译 功能！
-    请务必根据您的需求及时调整设置，以提高翻译的准确性和效率。
-    更多参考资源：
-    - 📘 [相关教程还没出噢](https://xnnehang.top/)
-
-    """
-    )
-    st.markdown("")
-    if st.button(
-        "**我已知晓&nbsp;&nbsp;&nbsp;本次不再弹出**",
-        type="primary",
-        use_container_width=True,
-        key="guide",
-    ):
-        st.session_state.welcome = True
-        st.rerun()
-
+guide = st.session_state.get(audio_keys["guide"], audio_settings.guide)
+output_type = st.session_state.get(audio_keys["output_type"], audio_settings.output_type)
+subtitle_speed = st.session_state.get(audio_keys["subtitle_speed"], audio_settings.subtitle_speed)
+cut_line = st.session_state.get(audio_keys["cut_line"], settings.cut_line)
+combine_line = st.session_state.get(audio_keys["combine_line"], settings.combine_line)
+max_sentence_length = st.session_state.get(audio_keys["max_sentence_length"], settings.max_sentence_length)
 
 # 用于音频上传
-if "audio_name" not in st.session_state:
-    st.session_state.audio_name = None
-if "use_upload" not in st.session_state:
-    st.session_state.use_upload = False
-if "use_example" not in st.session_state:
-    st.session_state.use_example = False
-if "selected_file" not in st.session_state:
-    st.session_state.selected_file = None
+if audio_keys["audio_name"] not in st.session_state:
+    st.session_state[audio_keys["audio_name"]] = None
+if audio_keys["use_upload"] not in st.session_state:
+    st.session_state[audio_keys["use_upload"]] = False
+if audio_keys["use_example"] not in st.session_state:
+    st.session_state[audio_keys["use_example"]] = False
+if audio_keys["use_bilibili"] not in st.session_state:
+    st.session_state[audio_keys["use_bilibili"]] = False
+if audio_keys["audio_file"] not in st.session_state:
+    st.session_state[audio_keys["audio_file"]] = None
+
 
 # 用于音频识别
-if "response_with_timestamp" not in st.session_state:
-    st.session_state.response_with_timestamp = None
-if "text_result" not in st.session_state:
-    st.session_state.text_result = None
+if audio_keys["response_with_timestamp"] not in st.session_state:
+    st.session_state[audio_keys["response_with_timestamp"]] = None
+if audio_keys["text_result"] not in st.session_state:
+    st.session_state[audio_keys["text_result"]] = None
 
 # 字幕预览
-if "preview_srt_file" not in st.session_state:
-    st.session_state.preview_srt_file = None
+if audio_keys["preview_srt_file"] not in st.session_state:
+    st.session_state[audio_keys["preview_srt_file"]] = None
 
 
 # 用于消息提示
-if "readme" not in st.session_state and audio_settings.guide == "open":
+if audio_keys["readme"] not in st.session_state and audio_settings.guide == "open":
     AudioReadme()
-    st.session_state.readme = True
-if "welcome" in st.session_state:
+    st.session_state[audio_keys["readme"]] = True
+if audio_keys["welcome"] in st.session_state:
     st.toast("欢迎使用 ~", icon=":material/verified:")
     del st.session_state["welcome"]
-if "save" in st.session_state:
+if audio_keys["save"] in st.session_state:
     st.toast("参数已成功保存", icon=":material/verified:")
     del st.session_state["save"]
-if "upload" in st.session_state:
+if audio_keys["upload"] in st.session_state:
     st.toast("文件上传成功！", icon=":material/verified:")
     del st.session_state["upload"]
 
-tab1, tab2 = st.tabs(["**音频识别**", "**参数设置**"])
-with tab2:
+# ============== 2.页面布局
+
+working_tab , setting_tab = st.tabs(["**音频识别**", "**参数设置**"])
+
+
+# 2.1. 配置
+# 参数配置
+with setting_tab:
     AudioSave = st.container()
     AudioSetting = st.container(border=True)
 
@@ -122,7 +114,7 @@ with tab2:
                 audio_settings.zh_set_value("guide", guide)
                 audio_settings.zh_set_value("output_type", output_type)
                 write_settings_file("audio.toml", audio_settings)
-                st.session_state.save = True
+                st.session_state[audio_keys["save"]] = True
                 st.rerun()
         with col1:
             st.markdown("")
@@ -130,7 +122,15 @@ with tab2:
             st.markdown("### 参数设置")
             st.caption("Changing Parameter Settings")
 
-with tab1:
+# 2.2. 识别页面
+# 通过 ctrl + f 快速定位到需要的功能
+# 2.2.1. 音轨预览
+# 2.2.2. 字幕预览
+# 2.2.3. 字幕工具
+# 2.2.4. 上传文件
+# 2.2.5. 开始识别
+# 音频识别
+with working_tab:
     # 配置处理
     col1, col2 = st.columns([0.75, 0.25])  # 置顶标题、执行按钮流程模块
 
@@ -141,13 +141,14 @@ with tab1:
         st.subheader("AI 全自动音频识别")
         st.caption("AI Automatic Audio Recognize")
 
-    # 执行按钮流程模块
     with col2:
         st.markdown("")
         st.markdown("")
+        # 2.2.5. 开始识别
+        # 开始识别
         if st.button("**开始识别**", type="primary", use_container_width=True):
-            if "audio_file" in st.session_state:
-                audio_file = st.session_state.audio_file
+            if st.session_state["audio_file"] is not None:
+                audio_file = st.session_state[audio_keys["audio_file"]]
                 print("\n" + "=" * 50)
                 print("\n\033[1;39m*** XnneHangLab 音频识别 ***\033[0m")
                 st.toast(
@@ -157,56 +158,79 @@ with tab1:
 
                 msg_ved = st.toast("正在对音频进行预处理", icon=":material/graphic_eq:")
                 current_time = datetime.datetime.now().strftime("_%Y%m%d%H%M%S")
-                # 使用上传的音频文件
-                if st.session_state.use_upload:
+                # 方式一: 使用上传的音频文件
+                if st.session_state[audio_keys["use_upload"]]:
                     audio_first_name = audio_file.name.split(".")[0]
                     audio_last_name = audio_file.name.split(".")[-1]
-                    st.session_state.audio_name = audio_file.name
-                    st.session_state.cache_dir = Path(settings.cache_dir) / audio_first_name / current_time
-                    cache_dir = st.session_state.cache_dir
+                    st.session_state[audio_keys["audio_name"]] = audio_file.name
+                    cache_dir = Path(settings.cache_dir) / audio_first_name / current_time
                     cache_dir.mkdir(parents=True, exist_ok=True)
                     # TODO 这里只是复制到了 cache_Dir ,实际上， 我们需要把它处理成 wav.
-                    with (cache_dir / st.session_state.audio_name).open("wb") as file:
+                    with (cache_dir / st.session_state[audio_keys["audio_name"]]).open("wb") as file:
                         file.write(audio_file.getbuffer())
                     if audio_last_name != "wav":
                         msg_ved.toast("转转换音频为 wav 格式", icon=":material/graphic_eq:")
                         print("\n\033转换音频为 wav 格式\033[0m")
                         # 转换成接受的 wav
                         file_to_wav(
-                            input_path=cache_dir / st.session_state.audio_name,
+                            input_path=cache_dir / st.session_state[audio_keys["audio_name"]],
                             output_wav_path=cache_dir / (audio_first_name + ".wav"),
                         )
                         # 更正使用的文件名
-                        st.session_state.audio_name = audio_first_name + ".wav"
+                        st.session_state[audio_keys["audio_name"]] = audio_first_name + ".wav"
 
-                # 使用示例音频文件
-                elif st.session_state.use_example:
-                    if st.session_state.selected_file:
-                        audio_first_name = st.session_state.selected_file.split(".")[0]
-                        audio_last_name = st.session_state.selected_file.split(".")[-1]
+                # 方式二: 使用示例音频文件
+                elif st.session_state[audio_keys["use_example"]]:
+                    if st.session_state[audio_keys["audio_name"]]:
+                        audio_first_name = st.session_state[audio_keys["audio_name"]].split(".")[0]
+                        audio_last_name = st.session_state[audio_keys["audio_name"]].split(".")[-1]
                     else:
                         st.toast("请先选择示例文件", icon=":material/error:")
                         st.stop()
-                    st.session_state.audio_name = st.session_state.selected_file
-                    st.session_state.cache_dir = Path(settings.cache_dir) / audio_first_name / current_time
-                    cache_dir = st.session_state.cache_dir
+                    cache_dir = Path(settings.cache_dir) / audio_first_name / current_time
                     cache_dir.mkdir(parents=True, exist_ok=True)
                     shutil.copy(
-                        Path(f"examples/{st.session_state.audio_name}"),
-                        cache_dir / st.session_state.audio_name,
+                        Path(f"examples/{st.session_state[audio_keys['audio_name']]}"),
+                        cache_dir / st.session_state[audio_keys["audio_name"]],
                     )
                     if audio_last_name != "wav":
                         msg_ved.toast("转换音频为 wav 格式", icon=":material/graphic_eq:")
                         print("\n\033转换音频为 wav 格式\033[0m")
                         # 转换成接受的 wav
                         file_to_wav(
-                            input_path=cache_dir / st.session_state.audio_name,
+                            input_path=cache_dir / st.session_state[audio_keys["audio_name"]],
                             output_wav_path=cache_dir / (audio_first_name + ".wav"),
                         )
                         # 更正使用的文件名
-                        st.session_state.audio_name = audio_first_name + ".wav"
+                        st.session_state[audio_keys["audio_name"]] = audio_first_name + ".wav"
+
+                # 方式三: 使用 b站视频下载模块
+                elif st.session_state[audio_keys["use_bilibili"]]:
+                    if st.session_state[audio_keys["audio_name"]]:
+                        audio_first_name = st.session_state[audio_keys["audio_name"]].split(".")[0]
+                        audio_last_name = st.session_state[audio_keys["audio_name"]].split(".")[-1]
+                    else:
+                        st.toast("请先选择音频文件", icon=":material/error:")
+                        st.stop()
+
+                    cache_dir = Path(settings.cache_dir) / audio_first_name / current_time
+                    cache_dir.mkdir(parents=True, exist_ok=True)
+                    shutil.copy(
+                        Path(st.session_state[audio_keys["audio_file"]]),
+                        cache_dir / st.session_state[audio_keys["audio_name"]],
+                    )
+                    if audio_last_name != "wav":
+                        msg_ved.toast("转换音频为 wav 格式", icon=":material/graphic_eq:")
+                        print("\n\033转换音频为 wav 格式\033[0m")
+                        # 转换成接受的 wav
+                        file_to_wav(
+                            input_path=cache_dir / st.session_state[audio_keys["audio_name"]],
+                            output_wav_path=cache_dir / (audio_first_name + ".wav"),
+                        )
+                        # 更正使用的文件名
+                        st.session_state[audio_keys["audio_name"]] = audio_first_name + ".wav"
                 else:
-                    st.toast("请先上传音频文件", icon=":material/error:")
+                    st.toast("请先选择要处理的音频文件", icon=":material/error:")
                     st.stop()
 
                 msg_ved.toast("音频预处理完成", icon=":material/graphic_eq:")
@@ -221,19 +245,19 @@ with tab1:
                     model = Model.asr_full_version()
                     response_with_timestamp = generate_asr_results(
                         model=model,
-                        input_path=Path(cache_dir / st.session_state.audio_name),
+                        input_path=Path(cache_dir / st.session_state[audio_keys["audio_name"]]),
                     )
                     # 保存 response 到 json 文件
-                    st.session_state.response_with_timestamp = response_with_timestamp
+                    st.session_state[audio_keys["response_with_timestamp"]] = response_with_timestamp
                     sentences = convert_asr_response_to_sentences(response_with_timestamp)
                     # 保存字幕
                     print("\n\033[1;35m*** 正在生成 SRT 字幕文件 ***\033[0m\n")
-                    st.session_state.preview_srt_file = (
+                    st.session_state[audio_keys["preview_srt_file"]] = (
                         Path(settings.output_dir) / "audio" / (audio_first_name + ".srt")
                     )
                     write_srt_from_sentences(
                         sentences,
-                        st.session_state.preview_srt_file,
+                        st.session_state[audio_keys["preview_srt_file"]],
                     )
                     print("\033[1;34m🎉 字幕生成成功！\033[0m")
 
@@ -242,12 +266,12 @@ with tab1:
                     model = Model.asr_full_version()
                     response = generate_asr_results(
                         model=model,
-                        input_path=cache_dir / st.session_state.audio_name,
+                        input_path=cache_dir / st.session_state[audio_keys["audio_name"]],
                     )
                     msg_srt = st.toast("正在生成 txt 文件", icon=":material/edit_note:")
                     print("\n\033[1;35m*** 正在生成 txt 文件 ***\033[0m\n")
                     result = save_only_text_from_response(response, output_dir=Path(settings.output_dir) / "audio")
-                    st.session_state.text_result = result
+                    st.session_state[audio_keys["text_result"]] = result
                     msg_srt.toast("txt 文件生成完成", icon=":material/edit_note:")
                 print("\033[1;34m🎉 FunASR 识别成功！\033[0m")
                 msg_whs.toast("音频内容识别完成", icon=":material/colorize:")
@@ -260,15 +284,21 @@ with tab1:
     with st.expander("**Audio Preview / 音轨预览**", expanded=True, icon=":material/graphic_eq:"):
         col6, col7 = st.columns([0.9999999, 0.0000001])
     with col6:
+        # 2.2.1. 音轨预览
         st.caption("音频音轨")
-        if st.session_state.use_example:
-            audio_file = st.session_state.audio_file
+        if st.session_state[audio_keys["use_example"]]:
+            audio_file = st.session_state[audio_keys["audio_file"]]
             with Path(audio_file).open("rb") as f:
                 audio_bytes = f.read()
             st.audio(audio_bytes)
-        elif st.session_state.use_upload:
-            audio_data = st.session_state.audio_file.getbuffer()
-            audio_bytes = st.session_state.audio_file.getvalue()
+        elif st.session_state[audio_keys["use_upload"]]:
+            audio_data = st.session_state[audio_keys["audio_file"]].getbuffer()
+            audio_bytes = st.session_state[audio_keys["audio_file"]].getvalue()
+            st.audio(audio_bytes)
+        elif st.session_state[audio_keys["use_bilibili"]]:
+            audio_file = st.session_state[audio_keys["audio_file"]]
+            with Path(audio_file).open("rb") as f:
+                audio_bytes = f.read()
             st.audio(audio_bytes)
         else:
             st.info(
@@ -281,74 +311,18 @@ with tab1:
     col1, col2 = st.columns([0.75, 0.25])
     with col2:
         with st.expander("**Tool / 工具**", expanded=True, icon=":material/construction:"):
+            # 2.2.4. 上传文件
             st.caption("上传文件")
 
-            @st.dialog("上传音频文件 / 选择示例文件")
-            def upload_audio():
-                st.markdown("在这里上传您需要处理的音频文件，该模块一次只能处理一个，多个会互相覆盖。")
-                st.caption(
-                    """该服务用 frp 内网穿透,你看到的上传进度条只是上传到服务器,服务器还得发到我的电脑,所以会卡100%，所以请上传小文件试试水(<10MB)."""
-                )
-                st.caption(
-                    """另外，如果有对德国(欧洲地区)速度较快(下载速度可以达到超过20MB/s,目前大概只有10MB/s)的代理也可以向我推荐。"""
-                )
-                st.markdown("")
-
-                audio_file = st.file_uploader(
-                    "上传您的音频文件",
-                    type=["mp3", "mpga", "m4a", "wav"],
-                    label_visibility="collapsed",
-                    accept_multiple_files=False,
-                )
-                st.markdown("")
-                if st.button("**点击上传**", use_container_width=True, type="primary"):
-                    if audio_file is None:
-                        st.toast("请先上传文件", icon=":material/error:")
-                        pass
-                    else:
-                        st.session_state.audio_file = audio_file
-                        st.session_state.use_upload = True
-                        st.session_state.upload = True
-                        st.rerun()
-
-                st.markdown("**PS:** 因为卡 100% 真的很影响体验，这里提供了示例文件（都存在我的电脑中，不需要上传）。")
-                st.caption("example1: 截取了 example2 的第一句歌词， 我用来跑 CI/CD 的。")
-                st.caption(
-                    "example2: [【AI巴老师】难道看我失魂落魄,你竟然心动](https://www.bilibili.com/video/BV1314y1k73r/)"
-                )
-                st.markdown("")
-
-                select_file = st.selectbox(
-                    "选择示例文件",
-                    [
-                        "example1.wav",
-                        "example2.m4a",
-                    ],
-                )
-                if st.button("**使用示例文件**", use_container_width=True, type="primary"):
-                    if select_file == "example1.wav":
-                        st.session_state.audio_file = "examples/example1.wav"
-                        st.session_state.selected_file = select_file
-                        st.session_state.use_example = True
-                        st.session_state.upload = True
-                        st.rerun()
-                    elif select_file == "example2.m4a":
-                        st.session_state.audio_file = "examples/example2.m4a"
-                        st.session_state.selected_file = select_file
-                        st.session_state.use_example = True
-                        st.session_state.upload = True
-                        st.rerun()
-
-                st.markdown("")
-
             if st.button(
-                "**文件上传**",
+                "**上传音频文件**",
                 use_container_width=True,
                 type="primary",
                 key="upload_audio_button",
             ):
                 upload_audio()
 
+            # 2.2.3. 字幕工具
             st.caption("字幕工具")
 
             if st.toggle("自定义字幕", False, key="custom_subtitle"):
@@ -392,7 +366,7 @@ with tab1:
                     st.caption("单句最大长度，如果超过该长度就不再继续合并。")
                     st.markdown("")
 
-                if st.session_state.response_with_timestamp:
+                if st.session_state[audio_keys["response_with_timestamp"]]:
                     response_with_timestamp = st.session_state.response_with_timestamp
                     sentences = convert_asr_response_to_sentences(response_with_timestamp)
                     if subtitle_speed == "慢":
@@ -405,10 +379,10 @@ with tab1:
                         sentences = cut_sentences(sentences, cutline=cut_line)
                     else:
                         pass
-                    if st.session_state.preview_srt_file:
+                    if st.session_state[audio_keys["preview_srt_file"]]:
                         write_srt_from_sentences(
                             sentences=sentences,
-                            srt_file_path=Path(st.session_state.preview_srt_file),
+                            srt_file_path=Path(st.session_state[audio_keys["preview_srt_file"]]),
                         )
                 else:
                     st.toast(
@@ -421,13 +395,13 @@ with tab1:
                     )
 
             if st.button("**下载字幕**", use_container_width=True, type="primary"):
-                if st.session_state.preview_srt_file:
-                    with st.session_state.preview_srt_file.open("r", encoding="utf-8") as srt_file:
+                if st.session_state[audio_keys["preview_srt_file"]]:
+                    with st.session_state[audio_keys["preview_srt_file"]].open("r", encoding="utf-8") as srt_file:
                         srt_content = srt_file.read()
                     st.download_button(
-                        label=st.session_state.preview_srt_file.name,
+                        label=st.session_state[audio_keys["preview_srt_file"]].name,
                         data=srt_content,
-                        file_name=st.session_state.preview_srt_file.name,
+                        file_name=st.session_state[audio_keys["preview_srt_file"]].name,
                         mime="text/plain",
                     )
 
@@ -436,20 +410,21 @@ with tab1:
             st.divider()
 
     with col1:
+        # 2.2.2. 字幕预览
         with st.expander(
             "**Subtitle Preview / 字幕预览**",
             expanded=True,
             icon=":material/subtitles:",
         ):
-            if st.session_state.preview_srt_file:
+            if st.session_state[audio_keys["preview_srt_file"]]:
                 st.caption("字幕时间轴")
-                with st.session_state.preview_srt_file.open("r", encoding="utf-8") as srt_file:
+                with st.session_state[audio_keys["preview_srt_file"]].open("r", encoding="utf-8") as srt_file:
                     srt_content = srt_file.read()
                 srt_data = parse_srt_file(srt_content)
                 st.dataframe(srt_data, hide_index=True)  # type: ignore
-            elif st.session_state.text_result:
+            elif st.session_state[audio_keys["text_result"]]:
                 st.caption("提取到的文本")
-                st.markdown(st.session_state.text_result)
+                st.markdown(st.session_state[audio_keys["text_result"]])
             else:
                 st.info(
                     "##### 结果预览区域 \n\n&nbsp;\n\n**生成完毕后会在此区域自动显示字幕时间轴**\n\n 运行前，请在右侧使用上传文件工具导入你的音频文件！ \n\n&nbsp;\n\n&nbsp;",


### PR DESCRIPTION
- [x] feat: 可以直接在 `b站视频下载` 中单独下载`音频`, 然后在音频识别模块中使用。
- [x] fix: 修复 examples 从 `tests` 移动到 `examples` 后找不到文件.
- [x] refact: 使用 TypedDict 重构 session_state.keys -> `session_state[keys[key_name]]`. 防止因为指定的 key_name 不同导致未定义。   