### PR TITLE
:sparkles: feature: Add args for setting file in cli, and add exceptions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,5 +162,5 @@ build-backend = "hatchling.build"
 # < 3.11 不支持 *tuple 的解包。(_dataclass.py 中涉及)
 # 于是，该项目只能在 3.11 运行，3.12 及以上需要考虑手动升级 pytorch。
 
-# 因为本项目主体是用于 UI, 为了防止响应时间过长所以不少地方用到了 lazy-import 来处理 torch, funasr, pandas 等复杂库. 这些库导入在计算力比较低的库上几乎需要四五妙乃至更久的时间.
+# 因为本项目主体是用于 UI, 为了防止响应时间过长所以不少地方用到了 lazy-import 来处理 torch, funasr, pandas 等复杂库. 这些库导入在计算力比较低的库上几乎需要四五秒乃至更久的时间.
 # 如果你需要用于批处理, 或者要求响应速度比较快的, 那么可以考虑优化这些 lazy-import 的地方, 所有 lazy-import 均有用 `# Lazy-import` 标注, 你可以快速搜索.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,7 @@ Issues = "https://github.com/XnneHangLab/XnneHangLab/issues"
 [project.scripts]
 test = "lab.test:main"
 acgo = "lab.cli:main"
-lab = "lab.ui:main"
-get_root = "lab.utils.get_root:main"
+get_root = "lab.utils.get_root:main" # 获取项目所在根目录绝对路径, 防止 streamlit UI 中默认以 `.` 作为根目录而找不到一些文件.
 
 [dependency-groups]
 dev = [
@@ -162,3 +161,6 @@ build-backend = "hatchling.build"
 # < 3.11 需要额外安装 tomlilib 
 # < 3.11 不支持 *tuple 的解包。(_dataclass.py 中涉及)
 # 于是，该项目只能在 3.11 运行，3.12 及以上需要考虑手动升级 pytorch。
+
+# 因为本项目主体是用于 UI, 为了防止响应时间过长所以不少地方用到了 lazy-import 来处理 torch, funasr, pandas 等复杂库. 这些库导入在计算力比较低的库上几乎需要四五妙乃至更久的时间.
+# 如果你需要用于批处理, 或者要求响应速度比较快的, 那么可以考虑优化这些 lazy-import 的地方, 所有 lazy-import 均有用 `# Lazy-import` 标注, 你可以快速搜索.

--- a/src/lab/cli.py
+++ b/src/lab/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -12,6 +13,7 @@ from lab.BasicRunner.converter import (
     convert_asr_response_to_sentences,
 )
 from lab.BasicRunner.cutter import cut_sentences
+from lab.exceptions import ErrorCode
 from lab.utils.config import load_settings_file
 from lab.utils.console.logger import Badge, Logger
 from lab.utils.model import FunASRModel, generate_asr_results
@@ -27,22 +29,25 @@ def main():
     argparser = argparse.ArgumentParser(description="将wav音频转换成srt")
     argparser.add_argument("-i", "--input_path", default="./examples/example1.wav", help="输入音频文件")
     argparser.add_argument("-o", "--output_path", default="./output/example1.srt", help="输出srt文件")
-    # argparser.add_argument("--only-text", store_true, help="是否只输出文本")
+    argparser.add_argument("--only-text", action="store_true", help="是否只输出文本")
     argparser.add_argument("--debug", action="store_true", help="是否开启debug模式")
 
     args = argparser.parse_args()
     audio_file_path = Path(args.input_path)
     srt_file_path = Path(args.output_path)
     debug = args.debug
-
+    only_text = args.only_text
     Model = FunASRModel()
-    model = Model.asr_full_version()
+    if only_text:
+        model = Model.only_txt()  # 似乎更快了一点, 但是没了标点 0.7s -> 0.55s.
+    else:
+        model = Model.asr_full_version()
 
     settings: RunnerSettings = load_settings_file("global.toml", RunnerSettings)
 
     if debug:
         Logger.info("正在使用 Debug 模式, 该模式直接打印调试信息~")
-        Logger.custom(settings, badge=Badge("配置文件",  fore="black", back="cyan"))
+        Logger.custom(settings, badge=Badge("全局配置", fore="black", back="cyan"))
         start = time.time()
         response = generate_asr_results(model=model, input_path=audio_file_path)
         end = time.time()
@@ -64,15 +69,17 @@ def main():
         response: ASRResponse = generate_asr_results(model=model, input_path=audio_file_path)
         sentences = convert_asr_response_to_sentences(response)
         if settings.cut and settings.combine:
-            if settings.combine_line < settings.cut_line:
-                raise ValueError("combine_line should be greater than cut_line, or all cut will be ignored.")
+            Logger.error("并不支持既裁剪又合并噢~")
+            sys.exit(ErrorCode.COMBINE_CUT_ERROR.value)
         elif settings.cut and not settings.combine:
-            if settings.combine_line < 0:
-                raise ValueError("cut_line should be greater than 0.")
+            if settings.cut_line < 0:
+                Logger.error("cut_line 应该大于 0 ~")
+                sys.exit(ErrorCode.COMBINE_CUT_ERROR.value)
             sentences = cut_sentences(sentences=sentences, cutline=settings.combine_line)
         elif not settings.cut and settings.combine:
             if settings.combine_line < 0:
-                raise ValueError("combine_line should be greater than 0.")
+                Logger.error("combine_line 应该大于 0 ~")
+                sys.exit(ErrorCode.COMBINE_CUT_ERROR.value)
             sentences = combine_sentences(
                 sentences=sentences,
                 combine_line=settings.combine_line,

--- a/src/lab/cli.py
+++ b/src/lab/cli.py
@@ -23,33 +23,97 @@ from lab.utils.TxtHelper import split_text_into_sentences_by_punctuation_list
 if TYPE_CHECKING:
     from lab._typing import ASRResponse, DebugMessage
 
+def path_from_cli(path: str) -> Path:
+    """从命令行参数获取路径，支持 ~，以便配置中使用 ~"""
+    return Path(path).expanduser()
+
+
+def validate_basic_setting(args: argparse.Namespace):
+    """检查传参修改后的基础配置 `global.toml` 的配置项是否存在冲突"""
+    Logger.info("正在检查配置项的合法性~")
+    # COMBINE_CUT_ERROR
+    if args.cut and args.combine:
+        Logger.error("并不支持既裁剪(cut=true)又合并(combine=true)噢~")
+        sys.exit(ErrorCode.COMBINE_CUT_ERROR.value)
+    elif args.cut and not args.combine:
+        if args.cut_line < 0:
+            Logger.error("cut_line 应该大于 0 ~")
+            sys.exit(ErrorCode.COMBINE_CUT_ERROR.value)
+    elif not args.cut and args.combine:
+        if args.combine_line < 0:
+            Logger.error("combine_line 应该大于 0 ~")
+            sys.exit(ErrorCode.COMBINE_CUT_ERROR.value)
+
+    # MODEL_FILE_NOT_FOUND_ERROR
+    if not args.base_model.exists():
+        Logger.error(f"asr_base 模型路径不存在: {args.base_model}")
+        sys.exit(ErrorCode.MODEL_FILE_NOT_FOUND_ERROR.value)
+    if not args.vad_model.exists():
+        Logger.error(f"vad 模型路径不存在: {args.vad_model}")
+        sys.exit(ErrorCode.MODEL_FILE_NOT_FOUND_ERROR.value)
+    if not args.punc_model.exists():
+        Logger.error(f"punc 模型路径不存在: {args.punc_model}")
+        sys.exit(ErrorCode.MODEL_FILE_NOT_FOUND_ERROR.value)
+
+    # TODO FFmpeg 应该也得找个地方验证一下, 但是在这里运行可能耗时太长了.
+
+def show_args(args: argparse.Namespace):
+    for key, value in vars(args).items():
+        Logger.custom(value, Badge(key, fore="green"))
 
 # 定义长文本写入函数
 def main():
-    argparser = argparse.ArgumentParser(description="将wav音频转换成srt")
-    argparser.add_argument("-i", "--input_path", default="./examples/example1.wav", help="输入音频文件")
-    argparser.add_argument("-o", "--output_path", default="./output/example1.srt", help="输出srt文件")
-    argparser.add_argument("--only-text", action="store_true", help="是否只输出文本")
-    argparser.add_argument("--debug", action="store_true", help="是否开启debug模式")
+    parser = argparse.ArgumentParser(description="将wav音频转换成srt")
+    settings: RunnerSettings = load_settings_file("global.toml", RunnerSettings)
+    # basic-setting
+    group_config = parser.add_argument_group("setting", "配置项")
+    group_config.add_argument("--batch_size_s", type=int, default=settings.batch_size_s, help=f"批处理大小, 默认为 {settings.batch_size_s}")
+    group_config.add_argument("--device", type=str, default=settings.device, help=f"计算设备(cpu/gpu), 默认为 {settings.device}")
+    group_config.add_argument("--output-dir", type=path_from_cli, default=path_from_cli(settings.output_dir), help="输出目录")
+    group_config.add_argument("--cache_dir", type=path_from_cli, default=path_from_cli(settings.cache_dir), help="缓存目录")
+    group_config.add_argument("--hotwords", type=str, default=settings.hot_words_path, help="热词或者热词(txt)的路径")
+    group_config.add_argument("--ffmpeg-path", type=str, default=settings.FFMPEG_PATH, help="ffmpeg的路径")
+    group_config.add_argument("--base-model", type=path_from_cli, default=path_from_cli(settings.base_model), help="基础模型的路径")
+    group_config.add_argument("--punc-model", type=path_from_cli, default=path_from_cli(settings.punc_model), help="分词模型的路径")
+    group_config.add_argument("--vad-model", type=path_from_cli, default=path_from_cli(settings.vad_model), help="VAD模型的路径")
+    group_config.add_argument("--cut", action="store_true", help="是否裁剪长句, 不可以和合并短句同时使用")
+    group_config.add_argument("--combine", action="store_true", help="是否合并短句, 不可以和裁剪长句同时使用")
+    group_config.add_argument("--combine-line", type=int, default=settings.combine_line, help=f"合并短句的间隔临界值(ms), 默认为 {settings.combine_line} ")
+    group_config.add_argument("--cut-line", type=int, default=settings.cut_line, help=f"裁剪长句的间隔临界值(ms), 默认为 {settings.cut_line} ")
+    group_config.add_argument("--max-sentence-length", type=int, default=settings.max_sentence_length, help=f"最大句子长度,默认为 {settings.max_sentence_length} , 当句子超过这个长度时,就不再合并了")
+    group_config.add_argument("--need-punc", action="store_true", help="是否需要标点符号")
+    # 隐藏了 punc_list , custom_output_dir, 前者除非出现新的未知标点符号导致 list index out of range 否则不需要修改, 后者只是用于维持 WebUI 的状态的.
 
-    args = argparser.parse_args()
-    audio_file_path = Path(args.input_path)
-    srt_file_path = Path(args.output_path)
-    debug = args.debug
-    only_text = args.only_text
+    group_basic = parser.add_argument_group("basic", "基础参数")
+    group_basic.add_argument("-i", "--input_path", type=path_from_cli, default=path_from_cli("./examples/example1.wav"), help="输入音频文件路径")
+    group_basic.add_argument("-o", "--output_path", type=path_from_cli, default=path_from_cli("./output/example1.srt"), help="输出 srt 文件路径")
+    group_basic.add_argument("--only-text", action="store_true", help="是否使用 Model.only_txt(), 更快, 但是没有标点和停顿")
+    group_basic.add_argument("--debug", action="store_true", help="是否开启debug模式")
+    group_basic.add_argument("--show-config", action="store_true", help="是否打印配置项")
+
+    # 读取 group_config 的参数
+    args = parser.parse_args()
+
+    # 允许用户临时修改配置项, 但不会更改到 global.toml 中
+    validate_basic_setting(args)
+    if args.show_config:
+        cfg_keys = [a.dest for a in group_config._group_actions]
+        group_config_args = argparse.Namespace(
+            **{k: getattr(args, k) for k in cfg_keys}
+        )
+        Logger.custom("加载配置项...", Badge("配置", fore="black", back="cyan"))
+        show_args(group_config_args)
+
     Model = FunASRModel()
-    if only_text:
+    if args.only_text:
         model = Model.only_txt()  # 似乎更快了一点, 但是没了标点 0.7s -> 0.55s.
     else:
         model = Model.asr_full_version()
 
-    settings: RunnerSettings = load_settings_file("global.toml", RunnerSettings)
-
-    if debug:
+    if args.debug: # TODO: 实际上这个执行的是独立任务, 如果 main() 变得过于复杂,可以把它拆到独立的 pyproject.script
         Logger.info("正在使用 Debug 模式, 该模式直接打印调试信息~")
-        Logger.custom(settings, badge=Badge("全局配置", fore="black", back="cyan"))
         start = time.time()
-        response = generate_asr_results(model=model, input_path=audio_file_path)
+        response = generate_asr_results(model=model, input_path=args.input_path)
         end = time.time()
         Logger.info(f"ASR 实际耗时: {end - start:.2f}秒")
         segmented_text = split_text_into_sentences_by_punctuation_list(response["text"])
@@ -66,25 +130,17 @@ def main():
         Logger.info(debug_message)
     else:
         # TODO: 设置 Logger 告知用户自己正在使用哪种模式.
-        response: ASRResponse = generate_asr_results(model=model, input_path=audio_file_path)
+        response: ASRResponse = generate_asr_results(model=model, input_path=args.input_path)
         sentences = convert_asr_response_to_sentences(response)
-        if settings.cut and settings.combine:
-            Logger.error("并不支持既裁剪又合并噢~")
-            sys.exit(ErrorCode.COMBINE_CUT_ERROR.value)
-        elif settings.cut and not settings.combine:
-            if settings.cut_line < 0:
-                Logger.error("cut_line 应该大于 0 ~")
-                sys.exit(ErrorCode.COMBINE_CUT_ERROR.value)
+        # 参数合法性在 validate_basic_setting 中已经检查过了
+        if settings.cut and not settings.combine:
             sentences = cut_sentences(sentences=sentences, cutline=settings.combine_line)
         elif not settings.cut and settings.combine:
-            if settings.combine_line < 0:
-                Logger.error("combine_line 应该大于 0 ~")
-                sys.exit(ErrorCode.COMBINE_CUT_ERROR.value)
             sentences = combine_sentences(
                 sentences=sentences,
                 combine_line=settings.combine_line,
                 max_sentence_length=settings.max_sentence_length,
             )
-        else:
+        else: # 不裁剪也不合并
             pass
-        write_srt_from_sentences(sentences=sentences, srt_file_path=srt_file_path)
+        write_srt_from_sentences(sentences=sentences, srt_file_path=args.output_path)

--- a/src/lab/cli.py
+++ b/src/lab/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -12,7 +13,7 @@ from lab.BasicRunner.converter import (
 )
 from lab.BasicRunner.cutter import cut_sentences
 from lab.utils.config import load_settings_file
-from lab.utils.console.logger import Logger
+from lab.utils.console.logger import Badge, Logger
 from lab.utils.model import FunASRModel, generate_asr_results
 from lab.utils.SrtHelper import write_srt_from_sentences
 from lab.utils.TxtHelper import split_text_into_sentences_by_punctuation_list
@@ -33,19 +34,19 @@ def main():
     audio_file_path = Path(args.input_path)
     srt_file_path = Path(args.output_path)
     debug = args.debug
-    if debug:
-        Logger.info("Debug 模式不会写入 srt 文件, 而是直接打印~")
 
     Model = FunASRModel()
     model = Model.asr_full_version()
 
     settings: RunnerSettings = load_settings_file("global.toml", RunnerSettings)
 
-    response: ASRResponse = generate_asr_results(model=model, input_path=audio_file_path)
-
     if debug:
-        # 应该写入，然后查找是否有除了中英文之外的符号。最后加入 config.punctuation_list
-        print(split_text_into_sentences_by_punctuation_list(response["text"]))
+        Logger.info("正在使用 Debug 模式, 该模式直接打印调试信息~")
+        Logger.custom(settings, badge=Badge("配置文件",  fore="black", back="cyan"))
+        start = time.time()
+        response = generate_asr_results(model=model, input_path=audio_file_path)
+        end = time.time()
+        Logger.info(f"ASR 实际耗时: {end - start:.2f}秒")
         segmented_text = split_text_into_sentences_by_punctuation_list(response["text"])
         total_words_num = 0
         for sentence in segmented_text:
@@ -56,10 +57,11 @@ def main():
             "total_words_num": total_words_num,
             "total_ts_num": len(response["timestamp"]),
         }
-        # 比对长度，如果不一样，说明有多余的未加入的符号。并且这个符号被计入 total_words_num 中。
+        # 比对长度，如果不一样，说明有多余的未加入的符号。并且这个符号被计入 total_words_num 中。 这时候就会出现 list index out of range 的错误。 可以通过排查该符号然后加入 punc_list 来解决。
         Logger.info(debug_message)
     else:
         # TODO: 设置 Logger 告知用户自己正在使用哪种模式.
+        response: ASRResponse = generate_asr_results(model=model, input_path=audio_file_path)
         sentences = convert_asr_response_to_sentences(response)
         if settings.cut and settings.combine:
             if settings.combine_line < settings.cut_line:

--- a/src/lab/cli.py
+++ b/src/lab/cli.py
@@ -12,6 +12,7 @@ from lab.BasicRunner.converter import (
 )
 from lab.BasicRunner.cutter import cut_sentences
 from lab.utils.config import load_settings_file
+from lab.utils.console.logger import Logger
 from lab.utils.model import FunASRModel, generate_asr_results
 from lab.utils.SrtHelper import write_srt_from_sentences
 from lab.utils.TxtHelper import split_text_into_sentences_by_punctuation_list
@@ -21,17 +22,19 @@ if TYPE_CHECKING:
 
 
 # 定义长文本写入函数
-def main() -> DebugMessage | None:
+def main():
     argparser = argparse.ArgumentParser(description="将wav音频转换成srt")
-    argparser.add_argument("-i", "--input_path", default="./example.wav", help="输入音频文件")
-    argparser.add_argument("-o", "--output_path", default="./example.srt", help="输出srt文件")
+    argparser.add_argument("-i", "--input_path", default="./examples/example1.wav", help="输入音频文件")
+    argparser.add_argument("-o", "--output_path", default="./output/example1.srt", help="输出srt文件")
     # argparser.add_argument("--only-text", store_true, help="是否只输出文本")
-    argparser.add_argument("-d", "--debug", default=False, help="是否开启debug模式")
+    argparser.add_argument("--debug", action="store_true", help="是否开启debug模式")
 
     args = argparser.parse_args()
     audio_file_path = Path(args.input_path)
     srt_file_path = Path(args.output_path)
     debug = args.debug
+    if debug:
+        Logger.info("Debug 模式不会写入 srt 文件, 而是直接打印~")
 
     Model = FunASRModel()
     model = Model.asr_full_version()
@@ -41,7 +44,6 @@ def main() -> DebugMessage | None:
     response: ASRResponse = generate_asr_results(model=model, input_path=audio_file_path)
 
     if debug:
-        # TODO: 加入Logger告知用户正在用debug模式,该模式不会生成最终文件.
         # 应该写入，然后查找是否有除了中英文之外的符号。最后加入 config.punctuation_list
         print(split_text_into_sentences_by_punctuation_list(response["text"]))
         segmented_text = split_text_into_sentences_by_punctuation_list(response["text"])
@@ -55,7 +57,7 @@ def main() -> DebugMessage | None:
             "total_ts_num": len(response["timestamp"]),
         }
         # 比对长度，如果不一样，说明有多余的未加入的符号。并且这个符号被计入 total_words_num 中。
-        return debug_message
+        Logger.info(debug_message)
     else:
         # TODO: 设置 Logger 告知用户自己正在使用哪种模式.
         sentences = convert_asr_response_to_sentences(response)

--- a/src/lab/exceptions.py
+++ b/src/lab/exceptions.py
@@ -11,7 +11,10 @@ if TYPE_CHECKING:
 class ErrorCode(Enum):
     # 发生错误
     COMBINE_CUT_ERROR = 10
-    UNSUPPORTED_TYPE_ERROR = 12
+    MODEL_FILE_NOT_FOUND_ERROR = 11
+    FFMPEG_NOT_FOUND_ERROR = 12
+    UNSUPPORTED_TYPE_ERROR = 13
+
 
 class SuccessCode(Enum):
     SUCCESS = 0
@@ -33,6 +36,17 @@ class CombineCutError(BaseException):
     # combine 和 cut 不能同时使用
     # combine_line 和 cut_line 不应该 <0
     code = ErrorCode.COMBINE_CUT_ERROR
+
+
+class ModelFileNotFoundError(BaseException):
+    # 模型文件不存在, 或者路径错误
+    # 目前模型有, base_model, vad_model, punc_model, sense_voice_model
+    code = ErrorCode.MODEL_FILE_NOT_FOUND_ERROR
+
+
+class FFmpegNotFoundError(BaseException):
+    # ffmpeg 执行文件不存在
+    code = ErrorCode.FFMPEG_NOT_FOUND_ERROR
 
 
 class UnSupportedTypeError(BaseException):

--- a/src/lab/exceptions.py
+++ b/src/lab/exceptions.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+from enum import Enum
+from typing import TYPE_CHECKING, TypeAlias
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+
+class ErrorCode(Enum):
+    # 发生错误
+    COMBINE_CUT_ERROR = 10
+    UNSUPPORTED_TYPE_ERROR = 12
+
+class SuccessCode(Enum):
+    SUCCESS = 0
+
+
+ReturnCode: TypeAlias = ErrorCode | SuccessCode
+
+
+class BaseException(Exception):
+    code: ErrorCode
+    message: str
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+
+class CombineCutError(BaseException):
+    # combine 和 cut 不能同时使用
+    # combine_line 和 cut_line 不应该 <0
+    code = ErrorCode.COMBINE_CUT_ERROR
+
+
+class UnSupportedTypeError(BaseException):
+    code = ErrorCode.UNSUPPORTED_TYPE_ERROR
+
+
+def handleUncaughtException(exctype: type[Exception], exception: Exception, trace: TracebackType):
+    oldHook(exctype, exception, trace)
+    if isinstance(exception, BaseException):
+        sys.exit(exception.code.value)
+
+
+sys.excepthook, oldHook = handleUncaughtException, sys.excepthook
+
+
+if __name__ == "__main__":
+    try:
+        raise CombineCutError("combine_cut 参数错误")
+    except (CombineCutError, UnSupportedTypeError) as e:
+        print(e.code.value, e.message)
+        raise e

--- a/src/lab/utils/get_font.py
+++ b/src/lab/utils/get_font.py
@@ -28,6 +28,7 @@ def get_font_data():
                 file.write(font + "\n")
 
     elif system_type in ["Darwin"]:
+        # Lazy-import
         import re
         import subprocess
 
@@ -39,6 +40,7 @@ def get_font_data():
                 file.write(font + "\n")
 
     elif system_type in ["Linux"]:
+        # Lazy-import
         import subprocess
 
         result = subprocess.run(["fc-list", ":", "family"], capture_output=True, text=True)

--- a/src/lab/utils/model.py
+++ b/src/lab/utils/model.py
@@ -24,6 +24,7 @@ class FunASRModel:
         self.device: str = self.settings.device
 
     def asr_full_version(self):
+        # Lazy-import
         from funasr import AutoModel
 
         model = AutoModel(
@@ -37,6 +38,7 @@ class FunASRModel:
         return model
 
     def sense_voice(self):
+        # Lazy-import
         from funasr import AutoModel
 
         model = AutoModel(
@@ -49,18 +51,21 @@ class FunASRModel:
         return model
 
     def only_vad(self):
+        # Lazy-import
         from funasr import AutoModel
 
         model = AutoModel(model=self.vad_model, device=self.device, disable_update=True)  # 也可以添加在这里
         return model
 
     def only_txt(self):
+        # Lazy-import
         from funasr import AutoModel
 
         model = AutoModel(model=self.base_model, device=self.device, disable_update=True)  # 也可以添加在这里
         return model
 
     def only_puc(self):
+        # Lazy-import
         from funasr import AutoModel
 
         model = AutoModel(model=self.punc_model, device=self.device, disable_update=True)  # 也可以添加在这里

--- a/src/lab/utils/public.py
+++ b/src/lab/utils/public.py
@@ -13,12 +13,14 @@ if TYPE_CHECKING:
 
 
 def check_cuda_available() -> bool:
+    # Lazy-import
     import torch
 
     return torch.cuda.is_available()
 
 
 def parse_srt_file(srt_content: str) -> pd.DataFrame:
+    # Lazy-import
     import pandas as pd
 
     """


### PR DESCRIPTION
## 动机

终于暂时结束了非常长久的 yutto-uiya 开发, 虽然说还有不少可以做的, 但是总是已经不用捆绑死了, 因为第一个稳定版的 release 已经发出去了.

目前终于回归主线的开发, 不过在这之前, 我们也应该建立属于我们自己的 cli. 毕竟 UI 的开发是零碎的, 而 cli 的开发才是结构化的, 先开发好 cli 可以让 UI 直接调用就行, 而不用写得过于复杂.

同时这么急着一抽身就来写这个也是因为一个项目要用到我写好的关于 funasr 的部分.

## 做了啥

- [x] 标注了所有 lazy-import 的地方, 方便运行速度优化
- [x] 为 toml 配置项增加对应的 args , 而不是只能通过修改 toml 文件, 另外, args 和 toml 可以共存, args 优先级高于 toml. 
- [x] 增加了 exceptions 对可能出现的意外进行结构化管理而不是在出现时再 raise.  
