### PR TITLE
:recycle: refactor: database fastapi return Pydantic BaseModel instead of beanie Document.

### DIFF
--- a/src/lab/database/crud/product_review.py
+++ b/src/lab/database/crud/product_review.py
@@ -30,21 +30,17 @@ def add_product_review(
     payload = review_data.model_dump(mode="json")
     try:
         response = requests.post(url, json=payload)  # requests library automatically serializes the dictionary to JSON
-        response.raise_for_status()  # Raises HTTPError for bad responses (4xx or 5xx)
-        response_json = response.json()  # Get the JSON response
-        Logger.info("添加成功")
-
-        # Parse the JSON response back into a ProductReview object
-        # This will also handle datetime string parsing if the 'date' field is present and valid
-        return MessageResponse(**response_json)  # Use model_validate for parsing from dict
     except requests.exceptions.RequestException as e:
-        Logger.error(f"添加产品评论时发生错误: {e}")
-        if hasattr(e, "response") and e.response is not None:
-            Logger.error(f"错误响应: {e.response.text}")
+        Logger.error("请检查是否运行了 just db-server, 以及 MongoDB 服务是否运行正常")
         return None
-    except Exception as e:  # Catch Pydantic validation errors or other parsing issues
-        Logger.error(f"解析服务器响应时发生错误: {e}")
-        return None
+
+    response.raise_for_status()  # Raises HTTPError for bad responses (4xx or 5xx)
+    response_json = response.json()  # Get the JSON response
+    Logger.info("添加成功")
+
+    # Parse the JSON response back into a ProductReview object
+    # This will also handle datetime string parsing if the 'date' field is present and valid
+    return MessageResponse(**response_json)  # Use model_validate for parsing from dict
 
 
 def get_all_reviews() -> list[ProductReviewDict] | None:
@@ -55,36 +51,19 @@ def get_all_reviews() -> list[ProductReviewDict] | None:
     url = f"{BASE_URL}/"
     try:
         response = requests.get(url)
-        response.raise_for_status()
-        reviews_json = response.json()
-        Logger.info("所有评论:")
-
-        parsed_reviews: list[ProductReviewDict] = []
-        for review_data in reviews_json:
-            try:
-                if "_id" in review_data:
-                    review_data["id"] = review_data.pop(
-                        "_id"
-                    )  # _id 似乎是 MongoDB 的默认字段名，而在 python 中我们的 _id 是被占用的。所以得把它转换为 id
-                # Parse into Pydantic model first for validation, then to dict for TypedDict return type
-                parsed_review = ProductReview.model_validate(review_data)
-                parsed_reviews.append(ProductReviewDict(**parsed_review.model_dump(mode="json")))
-            except Exception as e:
-                Logger.error(f"解析单个评论时发生错误: {e} - Data: {review_data}")
-                # Continue processing other reviews even if one fails
-                continue
-
-        for review in parsed_reviews:
-            print(review)
-        return parsed_reviews
     except requests.exceptions.RequestException as e:
-        Logger.error(f"获取所有评论时发生错误: {e}")
-        if hasattr(e, "response") and e.response is not None:
-            Logger.error(f"错误响应: {e.response.text}")
+        Logger.error("请检查是否运行了 just db-server, 以及 MongoDB 服务是否运行正常")
         return None
-    except Exception as e:
-        Logger.error(f"解析所有评论列表时发生错误: {e}")
-        return None
+    response.raise_for_status()
+    reviews_json = response.json()
+    Logger.info("所有评论:")
+
+    parsed_reviews: list[ProductReviewDict] = []
+    for review_data in reviews_json:
+        # Parse into Pydantic model first for validation, then to dict for TypedDict return type
+        parsed_review = ProductReview.model_validate(review_data)
+        parsed_reviews.append(ProductReviewDict(**parsed_review.model_dump(mode="json")))
+    return parsed_reviews
 
 
 def get_review_by_id(review_id: str) -> ProductReviewDict | None:
@@ -95,26 +74,22 @@ def get_review_by_id(review_id: str) -> ProductReviewDict | None:
     url = f"{BASE_URL}/{review_id}"
     try:
         response = requests.get(url)
-        response.raise_for_status()
-        review_json = response.json()
-
-        # Validate the response JSON against ProductReviewDict
-        if TYPE_CHECKING:
-            _ = ProductReviewDict(**review_json)  # Type check
-
-        # Parse into Pydantic model, then to dict for TypedDict return type
-        parsed_review = ProductReview.model_validate(review_json)
-        result_dict = parsed_review.model_dump(mode="json")
-        Logger.info(f"ID 为 '{review_id}' 的评论: {result_dict}")
-        return ProductReviewDict(**result_dict)
     except requests.exceptions.RequestException as e:
-        Logger.error(f"根据 ID '{review_id}' 获取评论时发生错误: {e}")
-        if hasattr(e, "response") and e.response is not None:
-            Logger.error(f"错误响应: {e.response.text}")
+        Logger.error("请检查是否运行了 just db-server, 以及 MongoDB 服务是否运行正常")
         return None
-    except Exception as e:
-        Logger.error(f"解析 ID 为 '{review_id}' 的评论时发生错误: {e}")
-        return None
+
+    response.raise_for_status()
+    review_json = response.json()
+
+    # Validate the response JSON against ProductReviewDict
+    if TYPE_CHECKING:
+        _ = ProductReviewDict(**review_json)  # Type check
+
+    # Parse into Pydantic model, then to dict for TypedDict return type
+    parsed_review = ProductReview.model_validate(review_json)
+    result_dict = parsed_review.model_dump(mode="json")
+    Logger.info(f"ID 为 '{review_id}' 的评论: {result_dict}")
+    return ProductReviewDict(**result_dict)
 
 
 def update_product_review_partial(review_id: str, updates: UpdateProductReview) -> ProductReviewDict | None:
@@ -128,26 +103,22 @@ def update_product_review_partial(review_id: str, updates: UpdateProductReview) 
     payload = updates.model_dump(mode="json", exclude_unset=True)
     try:
         response = requests.patch(url, json=payload)
-        response.raise_for_status()
-        updated_review_json = response.json()
-
-        # Validate the response JSON against ProductReviewDict
-        if TYPE_CHECKING:
-            _ = ProductReviewDict(**updated_review_json)  # Type check
-
-        # Parse into Pydantic model, then to dict for TypedDict return type
-        parsed_review = ProductReview.model_validate(updated_review_json)
-        result_dict = parsed_review.model_dump(mode="json")
-        Logger.info(f"ID 为 '{review_id}' 的评论已更新 (局部): {result_dict}")
-        return ProductReviewDict(**result_dict)
     except requests.exceptions.RequestException as e:
-        Logger.error(f"更新 ID 为 '{review_id}' 的评论时发生错误 (局部): {e}")
-        if hasattr(e, "response") and e.response is not None:
-            Logger.error(f"错误响应: {e.response.text}")
+        Logger.error("请检查是否运行了 just db-server, 以及 MongoDB 服务是否运行正常")
         return None
-    except Exception as e:
-        Logger.error(f"解析局部更新后的评论时发生错误: {e}")
-        return None
+
+    response.raise_for_status()
+    updated_review_json = response.json()
+
+    # Validate the response JSON against ProductReviewDict
+    if TYPE_CHECKING:
+        _ = ProductReviewDict(**updated_review_json)  # Type check
+
+    # Parse into Pydantic model, then to dict for TypedDict return type
+    parsed_review = ProductReview.model_validate(updated_review_json)
+    result_dict = parsed_review.model_dump(mode="json")
+    Logger.info(f"ID 为 '{review_id}' 的评论已更新 (局部): {result_dict}")
+    return ProductReviewDict(**result_dict)
 
 
 def replace_product_review_full(review_id: str, new_data: ProductReview) -> ProductReviewDict | None:
@@ -161,26 +132,22 @@ def replace_product_review_full(review_id: str, new_data: ProductReview) -> Prod
     payload = new_data.model_dump(mode="json", exclude_none=True)  # exclude_none for consistency
     try:
         response = requests.put(url, json=payload)
-        response.raise_for_status()
-        replaced_review_json = response.json()
-
-        # Validate the response JSON against ProductReviewDict
-        if TYPE_CHECKING:
-            _ = ProductReviewDict(**replaced_review_json)  # Type check
-
-        # Parse into Pydantic model, then to dict for TypedDict return type
-        parsed_review = ProductReview.model_validate(replaced_review_json)
-        result_dict = parsed_review.model_dump(mode="json")
-        Logger.info(f"ID 为 '{review_id}' 的评论已更新 (完全替换): {result_dict}")
-        return ProductReviewDict(**result_dict)
     except requests.exceptions.RequestException as e:
-        Logger.error(f"替换 ID 为 '{review_id}' 的评论时发生错误 (完全替换): {e}")
-        if hasattr(e, "response") and e.response is not None:
-            Logger.error(f"错误响应: {e.response.text}")
+        Logger.error("请检查是否运行了 just db-server, 以及 MongoDB 服务是否运行正常")
         return None
-    except Exception as e:
-        Logger.error(f"解析完全替换后的评论时发生错误: {e}")
-        return None
+
+    response.raise_for_status()
+    replaced_review_json = response.json()
+
+    # Validate the response JSON against ProductReviewDict
+    if TYPE_CHECKING:
+        _ = ProductReviewDict(**replaced_review_json)  # Type check
+
+    # Parse into Pydantic model, then to dict for TypedDict return type
+    parsed_review = ProductReview.model_validate(replaced_review_json)
+    result_dict = parsed_review.model_dump(mode="json")
+    Logger.info(f"ID 为 '{review_id}' 的评论已更新 (完全替换): {result_dict}")
+    return ProductReviewDict(**result_dict)
 
 
 def delete_product_review(review_id: str) -> MessageResponse | None:  # Return type changed to dict | None
@@ -191,14 +158,10 @@ def delete_product_review(review_id: str) -> MessageResponse | None:  # Return t
     url = f"{BASE_URL}/{review_id}"
     try:
         response = requests.delete(url)
-        response.raise_for_status()
-        Logger.info(f"ID 为 '{review_id}' 的评论已删除")
-        return MessageResponse(**response.json())  # Backend returns {"message": "Record deleted successfully"}
     except requests.exceptions.RequestException as e:
-        Logger.error(f"删除 ID 为 '{review_id}' 的评论时发生错误: {e}")
-        if hasattr(e, "response") and e.response is not None:
-            Logger.error(f"错误响应: {e.response.text}")
+        Logger.error("请检查是否运行了 just db-server, 以及 MongoDB 服务是否运行正常")
         return None
-    except Exception as e:
-        Logger.error(f"删除评论时发生错误: {e}")
-        return None
+
+    response.raise_for_status()
+    Logger.info(f"ID 为 '{review_id}' 的评论已删除")
+    return MessageResponse(**response.json())  # Backend returns {"message": "Record deleted successfully"}

--- a/src/lab/database/crud/product_review.py
+++ b/src/lab/database/crud/product_review.py
@@ -30,7 +30,7 @@ def add_product_review(
     payload = review_data.model_dump(mode="json")
     try:
         response = requests.post(url, json=payload)  # requests library automatically serializes the dictionary to JSON
-    except requests.exceptions.RequestException as e:
+    except requests.exceptions.RequestException:
         Logger.error("请检查是否运行了 just db-server, 以及 MongoDB 服务是否运行正常")
         return None
 
@@ -51,7 +51,7 @@ def get_all_reviews() -> list[ProductReviewDict] | None:
     url = f"{BASE_URL}/"
     try:
         response = requests.get(url)
-    except requests.exceptions.RequestException as e:
+    except requests.exceptions.RequestException:
         Logger.error("请检查是否运行了 just db-server, 以及 MongoDB 服务是否运行正常")
         return None
     response.raise_for_status()
@@ -74,7 +74,7 @@ def get_review_by_id(review_id: str) -> ProductReviewDict | None:
     url = f"{BASE_URL}/{review_id}"
     try:
         response = requests.get(url)
-    except requests.exceptions.RequestException as e:
+    except requests.exceptions.RequestException:
         Logger.error("请检查是否运行了 just db-server, 以及 MongoDB 服务是否运行正常")
         return None
 
@@ -103,7 +103,7 @@ def update_product_review_partial(review_id: str, updates: UpdateProductReview) 
     payload = updates.model_dump(mode="json", exclude_unset=True)
     try:
         response = requests.patch(url, json=payload)
-    except requests.exceptions.RequestException as e:
+    except requests.exceptions.RequestException:
         Logger.error("请检查是否运行了 just db-server, 以及 MongoDB 服务是否运行正常")
         return None
 
@@ -132,7 +132,7 @@ def replace_product_review_full(review_id: str, new_data: ProductReview) -> Prod
     payload = new_data.model_dump(mode="json", exclude_none=True)  # exclude_none for consistency
     try:
         response = requests.put(url, json=payload)
-    except requests.exceptions.RequestException as e:
+    except requests.exceptions.RequestException:
         Logger.error("请检查是否运行了 just db-server, 以及 MongoDB 服务是否运行正常")
         return None
 
@@ -158,7 +158,7 @@ def delete_product_review(review_id: str) -> MessageResponse | None:  # Return t
     url = f"{BASE_URL}/{review_id}"
     try:
         response = requests.delete(url)
-    except requests.exceptions.RequestException as e:
+    except requests.exceptions.RequestException:
         Logger.error("请检查是否运行了 just db-server, 以及 MongoDB 服务是否运行正常")
         return None
 

--- a/src/lab/database/models/product_review.py
+++ b/src/lab/database/models/product_review.py
@@ -7,7 +7,9 @@ from pydantic import BaseModel, Field
 
 
 class ProductReview(BaseModel):
-    id: str | None = None  # This is optional for the Pydantic model, but will be set by Beanie
+    id: PydanticObjectId | None = Field(
+        default=None, alias="_id"
+    )  # This is optional for the Pydantic model, but will be set by Beanie
     name: str
     product: str
     rating: float
@@ -29,7 +31,7 @@ class ProductReviewDocument(Document):
     class Config:  # type: ignore
         json_schema_extra = {
             "example": {
-                "id": "60c72b2f9b1e8d001c8e4a2f",
+                "_id": "60c72b2f9b1e8d001c8e4a2f",
                 "name": "Abdulazeez",
                 "product": "TestDriven TDD Course",
                 "rating": 4.9,

--- a/src/lab/database/routes/product_review.py
+++ b/src/lab/database/routes/product_review.py
@@ -4,7 +4,7 @@ from beanie import PydanticObjectId  # noqa: TC002
 from fastapi import APIRouter, HTTPException
 
 from lab.database._typing import MessageResponse
-from lab.database.models.product_review import ProductReviewDocument, UpdateProductReview
+from lab.database.models.product_review import ProductReview, ProductReviewDocument, UpdateProductReview
 
 router = APIRouter()
 
@@ -16,19 +16,23 @@ async def add_product_review(review: ProductReviewDocument) -> MessageResponse:
 
 
 @router.get("/{id}", response_description="Review record retrieved")
-async def get_review_record(id: PydanticObjectId) -> ProductReviewDocument | None:
+async def get_review_record(id: PydanticObjectId) -> ProductReview | None:
     review = await ProductReviewDocument.get(id)
-    return review
+    if not review:
+        raise HTTPException(status_code=404, detail="Review record not found!")
+    return ProductReview.model_validate(review.model_dump(by_alias=True, exclude_none=True))
 
 
 @router.get("/", response_description="Review records retrieved")
-async def get_reviews() -> list[ProductReviewDocument]:
+async def get_reviews() -> list[ProductReview]:
     reviews = await ProductReviewDocument.find_all().to_list()
-    return reviews
+    if not reviews:
+        raise HTTPException(status_code=404, detail="No review records found!")
+    return [ProductReview.model_validate(doc.model_dump(by_alias=True, exclude_none=True)) for doc in reviews]
 
 
 @router.patch("/{id}", response_description="Review record updated")
-async def update_student_data(id: PydanticObjectId, req: UpdateProductReview) -> ProductReviewDocument:
+async def update_student_data(id: PydanticObjectId, req: UpdateProductReview) -> ProductReview:
     # 1. 获取现有记录
     existing_review = await ProductReviewDocument.get(id)
     if not existing_review:
@@ -46,7 +50,9 @@ async def update_student_data(id: PydanticObjectId, req: UpdateProductReview) ->
     # 如果请求体为空，或者所有字段都是 None（并且 exclude_unset=True 过滤掉了它们），
     # 那么 update_fields 将是空的，无需进行数据库操作。
     if not update_fields:
-        return existing_review  # 直接返回现有记录，不做任何更新
+        return ProductReview.model_validate(
+            existing_review.model_dump(by_alias=True, exclude_none=True)
+        )  # 直接返回现有记录，不做任何更新
 
     # 4. 使用 MongoDB 的 $set 操作符进行局部更新。
     # Beanie 的 update() 方法可以直接接收一个包含 MongoDB 操作符的字典。
@@ -61,11 +67,11 @@ async def update_student_data(id: PydanticObjectId, req: UpdateProductReview) ->
     # 可以选择重新从数据库中加载一次：
     # updated_review = await ProductReviewDocument.get(id)
     # return updated_review
-    return existing_review
+    return ProductReview.model_validate(existing_review.model_dump(by_alias=True, exclude_none=True))
 
 
 @router.put("/{id}", response_description="Review record fully updated")
-async def replace_review_data(id: PydanticObjectId, review_data: ProductReviewDocument) -> ProductReviewDocument:
+async def replace_review_data(id: PydanticObjectId, review_data: ProductReviewDocument) -> ProductReview:
     """
     通过完全替换现有评论记录来进行全量更新。
     如果请求体中缺少任何必填字段，或者字段类型不匹配，将返回 422 错误。
@@ -102,7 +108,7 @@ async def replace_review_data(id: PydanticObjectId, review_data: ProductReviewDo
     await new_review.save()  # 这将根据 new_review.id(_id) 执行 replaceOne
 
     # 6. 返回更新后的记录
-    return new_review
+    return ProductReview.model_validate(new_review.model_dump(by_alias=True, exclude_none=True))
 
 
 @router.delete("/{id}", response_description="Review record deleted from the database")

--- a/src/lab/database/setup.py
+++ b/src/lab/database/setup.py
@@ -4,9 +4,11 @@ import motor.motor_asyncio
 from beanie import init_beanie  # type: ignore
 
 from lab.database.models.product_review import ProductReviewDocument
+from lab.utils.console.logger import Logger
 
 
 async def init_db():
     client = motor.motor_asyncio.AsyncIOMotorClient("mongodb://localhost:27017/productreviews")  # type: ignore
-
-    await init_beanie(database=client.db_name, document_models=[ProductReviewDocument])  # type: ignore
+    Logger.info("等待连接 MongoDB...")
+    await init_beanie(database=client.XnneHangLab, document_models=[ProductReviewDocument])  # type: ignore
+    Logger.info("MongoDB 连接成功，Beanie 初始化完成。")


### PR DESCRIPTION
- [x] 在 fastapi 返回时就对 Document 进行 `basemodel.validate` 而不是返回时再对 response.json 进行验证。
- [x] 使用 `alias` 自动映射 `_id` 到 `id` 而不是手动替换 key. （很重要，这可以保证前后端调用时不会出现 `id` 和 `_id` 的分歧，保持一套相同的逻辑。）
- [x] 已知返回是 ProductPreview 转换的 response.json ，那么解析就不应该出错，所以去掉了大部分不必要的 try-except 仅保留 mongodb 服务器没运行或者 just db-server (fastapi server 没有运行两种情况)  