### PR TITLE
:bug: fix: auto mkdir with `parent=True` when create chat_history.

### DIFF
--- a/src/lab/chat_history_manager.py
+++ b/src/lab/chat_history_manager.py
@@ -50,7 +50,7 @@ def _ensure_conf_dir(conf_uid: str) -> str:
     safe_conf_uid = _sanitize_path_component(conf_uid)
     history_dir = Path("chat_history")
     base_dir = history_dir / safe_conf_uid
-    base_dir.mkdir(exist_ok=True)
+    base_dir.mkdir(exist_ok=True, parents=True)
     return str(base_dir)
 
 


### PR DESCRIPTION
- [x] 修复:
```shell
2025-07-02 14:12:25 | ERROR    | lab.api.routes.vtuber:websocket_endpoint:49 | Error in WebSocket connection: [WinError 3] 系统找不到指定的路径。: 'chat_history\\shizuku-local-001'
```

因为 mkdir 没传入 `parent=True` 参数。