### PR TITLE
♻️ refact: Add another api version of gsv to suit Chill-AI-Mod.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,19 +79,19 @@ justfile             # useful scripts like start or install models.
 
 ### 3.4. Docstrings & Comments (CRITICAL)
 
-  - All public modules, functions, classes, and methods **MUST** have a docstring in English.
+  - All public modules, functions, classes, and methods **MUST** have a docstring in English or Chinese.
   - Use the **Google Python Style** for docstrings.
   - Docstrings **MUST** include:
     1.  Summary.
     2.  `Args:` section describing each parameter, its type, and its purpose.
     3.  `Returns:` section describing the return value, its type, and its meaning.
     4.  (Optional but encouraged) `Raises:` section for any exceptions thrown.
-  - All other code comments must also be in English.
+  - All other code comments must also be in English or Chinese.
 
 ### 3.5. Logging
 
   - Use the `loguru` module for all informational or error output.
-  - Log messages should be in English, clear, and informative. Use emoji when appropriate.
+  - Log messages should be in English or Chinese, clear, and informative. Use emoji when appropriate.
 
 
 ### 3.6. For PR

--- a/justfile
+++ b/justfile
@@ -52,6 +52,9 @@ test-gsv:
 	&& uv run python -c "import json, base64; data=json.load(open('response.json')); open('output.mp3', 'wb').write(base64.b64decode(data['audio_byte']))"
 	rm response.json
 
+test-gsv-v2:
+    curl -G "http://127.0.0.1:12393/tts/gptsovitsv2/tts" --data-urlencode "text=こんにちは、お元気ですか？今日も一緒に頑張りましょう！" --data-urlencode "text_lang=ja" --data-urlencode "ref_audio_path=Voice_MainScenario_27_016.wav" --data-urlencode "prompt_text=君が集中した時のシータ波を検出して、リンクをつなぎ直せば元通りになるはず。" --data-urlencode "prompt_lang=ja" --data-urlencode "speed_factor=1.0" -o tts.wav
+
 
 test-deeplx:
 	curl -X POST "http://127.0.0.1:12393/translate/deeplx" \

--- a/src/lab/api/routes/gpt_sovits_v2.py
+++ b/src/lab/api/routes/gpt_sovits_v2.py
@@ -1,0 +1,141 @@
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
+from fastapi.responses import FileResponse, StreamingResponse
+
+from gsv.gsv_state_manager import gsv_tts_state_manager
+from lab.utils.FFmpegHelper import file_to_mp3
+
+router = APIRouter()
+
+REF_AUDIO_BASE_DIR = Path("./models/gptsovits/elaina").resolve()
+
+def _resolve_ref_audio_path(p: str) -> str:
+    cand = Path(p)
+    if not cand.is_absolute():
+        cand = (REF_AUDIO_BASE_DIR / cand).resolve()
+    else:
+        cand = cand.resolve()
+    if REF_AUDIO_BASE_DIR not in cand.parents and cand != REF_AUDIO_BASE_DIR:
+        raise HTTPException(status_code=400, detail="Invalid ref_audio_path (out of base dir)")
+    if not cand.exists():
+        raise HTTPException(status_code=404, detail=f"ref_audio_path not found: {cand}")
+    return str(cand)
+
+async def _read_request_data(request: Request) -> dict[str, Any]:
+    """
+    WebAPI v2 主要是 GET query；但也兼容 POST(json / form) 以防你后面还要复用。
+    """
+    if request.method == "GET":
+        return dict(request.query_params)
+
+    ctype = (request.headers.get("content-type") or "").lower()
+    if "application/json" in ctype:
+        try:
+            return await request.json()
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Invalid JSON body: {e}")
+
+    if "application/x-www-form-urlencoded" in ctype or "multipart/form-data" in ctype:
+        form = await request.form()
+        return dict(form)
+
+    # fallback：允许 query 兜底
+    return dict(request.query_params)
+
+def _normalize_webapi_v2_params(data: dict[str, Any]) -> dict[str, Any]:
+    """
+    把 WebAPI v2 参数名对齐到你内部可能用到的字段名。
+    - WebAPI v2: text_lang / prompt_lang
+    - 你现有：可能有 text_language / prompt_language
+    """
+    d = dict(data)
+
+    # 兼容 text_lang / text_language
+    if "text_lang" in d and "text_language" not in d:
+        d["text_language"] = d["text_lang"]
+    if "text_language" in d and "text_lang" not in d:
+        d["text_lang"] = d["text_language"]
+
+    # 兼容 prompt_lang / prompt_language
+    if "prompt_lang" in d and "prompt_language" not in d:
+        d["prompt_language"] = d["prompt_lang"]
+    if "prompt_language" in d and "prompt_lang" not in d:
+        d["prompt_lang"] = d["prompt_language"]
+
+    # ref_audio_path：建议转成绝对/安全路径（按你需要可移除这行）
+    if "ref_audio_path" in d and isinstance(d["ref_audio_path"], str) and d["ref_audio_path"].strip():
+        d["ref_audio_path"] = _resolve_ref_audio_path(d["ref_audio_path"].strip())
+
+    # 默认值
+    d.setdefault("speed_factor", 1.0)
+    d.setdefault("streaming_mode", False)
+
+    # WebAPI v2 默认输出 wav（AIChat README 也是下载 tts.wav）:contentReference[oaicite:2]{index=2}
+    d.setdefault("audio_type", "wav")
+
+    return d
+
+def _iter_file(path: Path, chunk_size: int = 1024 * 256):
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+
+@router.get("/tts")
+@router.post("/tts")
+async def tts_webapi_v2_compat(request: Request, background_tasks: BackgroundTasks):
+    raw = await _read_request_data(request)
+    data = _normalize_webapi_v2_params(raw)
+
+    # 必要参数（按 AIChat README 的测试链接）:contentReference[oaicite:3]{index=3}
+    text = (data.get("text") or "").strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="text cannot be empty")
+
+    # 你的内部实现如果必须要 sample_rate 等，params_parser 里一般会补齐；
+    # 这里不强行校验 sample_rate。
+
+    tts_synthesizer = gsv_tts_state_manager.get_tts_synthesizer()
+    if tts_synthesizer is None:
+        raise HTTPException(status_code=500, detail="TTS synthesizer not initialized")
+
+    task = tts_synthesizer.params_parser(data)  # type: ignore
+    save_path = tts_synthesizer.generate(task, return_type="filepath")  # type: ignore
+    if not isinstance(save_path, str):
+        raise HTTPException(status_code=500, detail="Failed to generate audio file")
+
+    out_path = Path(save_path)
+
+    # 输出类型：wav / mp3
+    audio_type = str(data.get("audio_type") or "wav").lower()
+    if audio_type == "mp3":
+        mp3_path = out_path.with_suffix(".mp3")
+        file_to_mp3(out_path, mp3_path)
+        out_path = mp3_path
+        media_type = "audio/mpeg"
+        filename = "tts.mp3"
+    elif audio_type == "wav":
+        media_type = "audio/wav"
+        filename = "tts.wav"
+    else:
+        raise HTTPException(status_code=400, detail=f"Unsupported audio_type: {audio_type}")
+
+    # 请求方可能会传 streaming_mode=True（README 里 ffplay 测试就用过）:contentReference[oaicite:4]{index=4}
+    streaming_mode = str(data.get("streaming_mode")).lower() in ("1", "true", "yes", "y", "on")
+
+    # （可选）响应结束后清理文件：看你是否想保留生成结果
+    # background_tasks.add_task(out_path.unlink, missing_ok=True)
+
+    if streaming_mode:
+        return StreamingResponse(_iter_file(out_path), media_type=media_type, headers={
+            "Content-Disposition": f'attachment; filename="{filename}"'
+        })
+    else:
+        return FileResponse(out_path, media_type=media_type, filename=filename)

--- a/src/lab/api/routes/gpt_sovits_v2.py
+++ b/src/lab/api/routes/gpt_sovits_v2.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 from pathlib import Path
@@ -6,13 +5,14 @@ from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 from fastapi.responses import FileResponse, StreamingResponse
-
 from gsv.gsv_state_manager import gsv_tts_state_manager
+
 from lab.utils.FFmpegHelper import file_to_mp3
 
 router = APIRouter()
 
 REF_AUDIO_BASE_DIR = Path("./models/gptsovits/elaina").resolve()
+
 
 def _resolve_ref_audio_path(p: str) -> str:
     cand = Path(p)
@@ -26,6 +26,7 @@ def _resolve_ref_audio_path(p: str) -> str:
         raise HTTPException(status_code=404, detail=f"ref_audio_path not found: {cand}")
     return str(cand)
 
+
 async def _read_request_data(request: Request) -> dict[str, Any]:
     """
     WebAPI v2 主要是 GET query；但也兼容 POST(json / form) 以防你后面还要复用。
@@ -38,7 +39,7 @@ async def _read_request_data(request: Request) -> dict[str, Any]:
         try:
             return await request.json()
         except Exception as e:
-            raise HTTPException(status_code=400, detail=f"Invalid JSON body: {e}")
+            raise HTTPException(status_code=400, detail=f"Invalid JSON body: {e}") from e
 
     if "application/x-www-form-urlencoded" in ctype or "multipart/form-data" in ctype:
         form = await request.form()
@@ -46,6 +47,7 @@ async def _read_request_data(request: Request) -> dict[str, Any]:
 
     # fallback：允许 query 兜底
     return dict(request.query_params)
+
 
 def _normalize_webapi_v2_params(data: dict[str, Any]) -> dict[str, Any]:
     """
@@ -80,6 +82,7 @@ def _normalize_webapi_v2_params(data: dict[str, Any]) -> dict[str, Any]:
 
     return d
 
+
 def _iter_file(path: Path, chunk_size: int = 1024 * 256):
     with path.open("rb") as f:
         while True:
@@ -88,9 +91,11 @@ def _iter_file(path: Path, chunk_size: int = 1024 * 256):
                 break
             yield chunk
 
+
 # 我为什么又写上了 /tts?
 # 因为 https://github.com/qzrs777/AIChat
 # 它的最终接口硬拼凑了一个 /tts 路径。暂时这么写，等我大改 Mod 的时候就会顺便修改掉那个硬拼的内容。
+
 
 @router.get("/tts/gptsovitsv2/tts")
 @router.post("/tts/gptsovitsv2/tts")
@@ -138,8 +143,10 @@ async def tts_webapi_v2_compat(request: Request, background_tasks: BackgroundTas
     # background_tasks.add_task(out_path.unlink, missing_ok=True)
 
     if streaming_mode:
-        return StreamingResponse(_iter_file(out_path), media_type=media_type, headers={
-            "Content-Disposition": f'attachment; filename="{filename}"'
-        })
+        return StreamingResponse(
+            _iter_file(out_path),
+            media_type=media_type,
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
     else:
         return FileResponse(out_path, media_type=media_type, filename=filename)

--- a/src/lab/api/routes/gpt_sovits_v2.py
+++ b/src/lab/api/routes/gpt_sovits_v2.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 from fastapi.responses import FileResponse, StreamingResponse
@@ -9,12 +9,18 @@ from gsv.gsv_state_manager import gsv_tts_state_manager
 
 from lab.utils.FFmpegHelper import file_to_mp3
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
 router = APIRouter()
 
 REF_AUDIO_BASE_DIR = Path("./models/gptsovits/elaina").resolve()
 
 
 def _resolve_ref_audio_path(p: str) -> str:
+    """
+    解析 ref_audio_path，确保它是绝对路径，且在 REF_AUDIO_BASE_DIR 下。
+    """
     cand = Path(p)
     if not cand.is_absolute():
         cand = (REF_AUDIO_BASE_DIR / cand).resolve()
@@ -83,7 +89,10 @@ def _normalize_webapi_v2_params(data: dict[str, Any]) -> dict[str, Any]:
     return d
 
 
-def _iter_file(path: Path, chunk_size: int = 1024 * 256):
+def _iter_file(path: Path, chunk_size: int = 1024 * 256) -> Generator[bytes, None, None]:
+    """
+    按 chunk_size 读取文件内容，返回字节流。
+    """
     with path.open("rb") as f:
         while True:
             chunk = f.read(chunk_size)
@@ -95,8 +104,6 @@ def _iter_file(path: Path, chunk_size: int = 1024 * 256):
 # 我为什么又写上了 /tts?
 # 因为 https://github.com/qzrs777/AIChat
 # 它的最终接口硬拼凑了一个 /tts 路径。暂时这么写，等我大改 Mod 的时候就会顺便修改掉那个硬拼的内容。
-
-
 @router.get("/tts/gptsovitsv2/tts")
 @router.post("/tts/gptsovitsv2/tts")
 async def tts_webapi_v2_compat(request: Request, background_tasks: BackgroundTasks):

--- a/src/lab/api/routes/gpt_sovits_v2.py
+++ b/src/lab/api/routes/gpt_sovits_v2.py
@@ -88,8 +88,12 @@ def _iter_file(path: Path, chunk_size: int = 1024 * 256):
                 break
             yield chunk
 
-@router.get("/tts/gptsovitsv2")
-@router.post("/tts/gptsovitsv2")
+# 我为什么又写上了 /tts?
+# 因为 https://github.com/qzrs777/AIChat
+# 它的最终接口硬拼凑了一个 /tts 路径。暂时这么写，等我大改 Mod 的时候就会顺便修改掉那个硬拼的内容。
+
+@router.get("/tts/gptsovitsv2/tts")
+@router.post("/tts/gptsovitsv2/tts")
 async def tts_webapi_v2_compat(request: Request, background_tasks: BackgroundTasks):
     raw = await _read_request_data(request)
     data = _normalize_webapi_v2_params(raw)

--- a/src/lab/api/routes/gpt_sovits_v2.py
+++ b/src/lab/api/routes/gpt_sovits_v2.py
@@ -88,8 +88,8 @@ def _iter_file(path: Path, chunk_size: int = 1024 * 256):
                 break
             yield chunk
 
-@router.get("/tts")
-@router.post("/tts")
+@router.get("/tts/gptsovitsv2")
+@router.post("/tts/gptsovitsv2")
 async def tts_webapi_v2_compat(request: Request, background_tasks: BackgroundTasks):
     raw = await _read_request_data(request)
     data = _normalize_webapi_v2_params(raw)

--- a/src/lab/server.py
+++ b/src/lab/server.py
@@ -143,8 +143,8 @@ class WebSocketServer:
             self.app.include_router(vits_router)
         if lab_settings.package.gpt_sovits:
             from lab.api.routes.gpt_sovits import router as gsv_router
-            from lab.api.routes.gpt_sovits_v2 import router as gsv_v2_router
             self.app.include_router(gsv_router)
+            from lab.api.routes.gpt_sovits_v2 import router as gsv_v2_router
             self.app.include_router(gsv_v2_router)
 
         # Mount static files

--- a/src/lab/server.py
+++ b/src/lab/server.py
@@ -143,8 +143,10 @@ class WebSocketServer:
             self.app.include_router(vits_router)
         if lab_settings.package.gpt_sovits:
             from lab.api.routes.gpt_sovits import router as gsv_router
+
             self.app.include_router(gsv_router)
             from lab.api.routes.gpt_sovits_v2 import router as gsv_v2_router
+
             self.app.include_router(gsv_v2_router)
 
         # Mount static files

--- a/src/lab/server.py
+++ b/src/lab/server.py
@@ -143,8 +143,9 @@ class WebSocketServer:
             self.app.include_router(vits_router)
         if lab_settings.package.gpt_sovits:
             from lab.api.routes.gpt_sovits import router as gsv_router
-
+            from lab.api.routes.gpt_sovits_v2 import router as gsv_v2_router
             self.app.include_router(gsv_router)
+            self.app.include_router(gsv_v2_router)
 
         # Mount static files
         logger.info(f"Mounting static files from {ROOT_DIR}")


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->

我原本的 gsv 被我封装起来了。和 gsv 的原生调用有些不同，导致无法通过这样的参数形式调用：

```shell
http://127.0.0.1:9880/tts?text=こんにちは、お元気ですか？今日も一緒に頑張りましょう！&text_lang=ja&ref_audio_path=Voice_MainScenario_27_016.wav&prompt_text=君が集中した時のシータ波を検出して、リンクをつなぎ直せば元通りになるはず。&prompt_lang=ja&speed_factor=1.0
```

https://github.com/qzrs777/AIChat

无法使用该 Mod 的 TTS 功能

## 解决方案

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

为了使用 Mod 我模仿着添加了一个新的 api 格式来作为兼容层，两者并存。我会手动修改和再编译 Chill AI Mod 的时候修改它的调用参数然后废弃这个额外的 gsv api。

添加测试脚本 `just test-gsv-v2`.

<img width="1919" height="1001" alt="image" src="https://github.com/user-attachments/assets/daffe9c9-fd70-421c-afa5-3e7949512143" />

Mod 的 TTS 成功连上！

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
