### PR TITLE
🧑‍💻 dx: add `just list-model` to list models for providers with api_key set in config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ chinese-roberta-wwm-ext-large/
 chinese-hubert-base/
 
 bfg-*.jar
+model_list.json

--- a/justfile
+++ b/justfile
@@ -1,6 +1,9 @@
 key:
   uv run scripts/sync_apikey.py  # 同步 API Key
 
+list-model: # 列出配置项中填写 api_key 的模型列表
+  uv run scripts/list_model_name.py
+
 start:
   uv lock
   uv sync

--- a/scripts/list_model_name.py
+++ b/scripts/list_model_name.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import requests
 from loguru import logger
@@ -10,7 +10,7 @@ from loguru import logger
 from lab.config_manager import XnneHangLabSettings, load_settings_file
 
 
-def fetch_model_list(base_url: str, api_key: Optional[str] = None, timeout: float = 10.0) -> list[str]:
+def fetch_model_list(base_url: str, api_key: str|None = None, timeout: float = 10.0) -> list[str]:
     """
     Assumes base_url is already a correct OpenAI-compatible prefix, e.g.:
       https://api.openai.com/v1
@@ -36,7 +36,7 @@ def fetch_model_list(base_url: str, api_key: Optional[str] = None, timeout: floa
     data = payload.get("data") if isinstance(payload, dict) else None  # type: ignore
     if not isinstance(data, list):
         raise RuntimeError(
-            f"Unexpected response shape from {url}: top-level keys={list(payload.keys()) if isinstance(payload, dict) else type(payload)}"
+            f"Unexpected response shape from {url}: top-level keys={list(payload.keys()) if isinstance(payload, dict) else type(payload)}"  # type: ignore
         )  # type: ignore
 
     ids: list[str] = []
@@ -65,6 +65,8 @@ def main() -> None:
     errors: dict[str, str] = {}
 
     for name, (base_url, api_key) in providers.items():
+        if not api_key:
+            continue
         try:
             model_map[name] = fetch_model_list(base_url, api_key=api_key)
         except Exception as e:
@@ -74,8 +76,7 @@ def main() -> None:
         logger.info(f"{k}: {v}")
     summary = {k: len(v) for k, v in model_map.items()}
     logger.info(f"model counts: {summary}")
-    if errors:
-        logger.warning(f"failed: {list(errors.keys())}")
+    logger.info("仅获取了有 api_key 的模型列表")
 
     # 需要完整列表就写到文件（或直接 print(model_map)）
     with Path("model_list.json").open("w", encoding="utf-8") as f:

--- a/scripts/list_model_name.py
+++ b/scripts/list_model_name.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+from loguru import logger
+
+from lab.config_manager import XnneHangLabSettings, load_settings_file
+
+
+def fetch_model_list(base_url: str, api_key: Optional[str] = None, timeout: float = 10.0) -> list[str]:
+    """
+    Assumes base_url is already a correct OpenAI-compatible prefix, e.g.:
+      https://api.openai.com/v1
+      https://generativelanguage.googleapis.com/v1beta/openai/
+    It will call: GET {base_url.rstrip('/')}/models
+
+    Returns: sorted unique model ids.
+    """
+    url = f"{base_url.rstrip('/')}/models"
+    headers = {"Accept": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    r = requests.get(url, headers=headers, timeout=timeout)
+    if not (200 <= r.status_code < 300):
+        # Many providers return HTML when blocked by Cloudflare; keep it short.
+        snippet = r.text[:300].replace("\n", " ")
+        raise RuntimeError(f"HTTP {r.status_code} from {url}: {snippet}")
+
+    payload: Any = r.json()
+
+    # OpenAI-compatible: {"object":"list","data":[{"id":"..."}]}
+    data = payload.get("data") if isinstance(payload, dict) else None  # type: ignore
+    if not isinstance(data, list):
+        raise RuntimeError(
+            f"Unexpected response shape from {url}: top-level keys={list(payload.keys()) if isinstance(payload, dict) else type(payload)}"
+        )  # type: ignore
+
+    ids: list[str] = []
+    for item in data:  # type: ignore
+        if isinstance(item, dict):
+            mid = item.get("id")  # type: ignore
+            if isinstance(mid, str):
+                ids.append(mid)
+
+    return sorted(set(ids))
+
+
+def main() -> None:
+    lab_settings: XnneHangLabSettings = load_settings_file("lab.toml", XnneHangLabSettings)
+    s = lab_settings.agent.llm
+
+    providers: dict[str, tuple[str, str]] = {
+        "openai": (s.openai.llm_base_url, s.openai.llm_api_key),
+        "cerebras": (s.cerebras.llm_base_url, s.cerebras.llm_api_key),
+        "gemini": (s.gemini.llm_base_url, s.gemini.llm_api_key),
+        "lingyi": (s.lingyi.llm_base_url, s.lingyi.llm_api_key),
+        "oaipro": (s.oaipro.llm_base_url, s.oaipro.llm_api_key),
+    }
+
+    model_map: dict[str, list[str]] = {}
+    errors: dict[str, str] = {}
+
+    for name, (base_url, api_key) in providers.items():
+        try:
+            model_map[name] = fetch_model_list(base_url, api_key=api_key)
+        except Exception as e:
+            errors[name] = str(e)
+
+    for k, v in model_map.items():
+        logger.info(f"{k}: {v}")
+    summary = {k: len(v) for k, v in model_map.items()}
+    logger.info(f"model counts: {summary}")
+    if errors:
+        logger.warning(f"failed: {list(errors.keys())}")
+
+    # 需要完整列表就写到文件（或直接 print(model_map)）
+    with Path("model_list.json").open("w", encoding="utf-8") as f:
+        json.dump(model_map, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/list_model_name.py
+++ b/scripts/list_model_name.py
@@ -50,6 +50,7 @@ def fetch_model_list(base_url: str, api_key: str|None = None, timeout: float = 1
 
 
 def main() -> None:
+    """列出配置项中填写 api_key 的模型列表"""
     lab_settings: XnneHangLabSettings = load_settings_file("lab.toml", XnneHangLabSettings)
     s = lab_settings.agent.llm
 

--- a/scripts/list_model_name.py
+++ b/scripts/list_model_name.py
@@ -7,7 +7,7 @@ import requests
 from loguru import logger
 from pydantic import BaseModel, ValidationError
 
-from lab.config_manager import XnneHangLabSettings, load_settings_file
+from lab.config_manager import RootAbsDir, XnneHangLabSettings, load_settings_file
 
 
 class ModelItem(BaseModel):
@@ -43,6 +43,7 @@ def main() -> None:
         None. Logs the results and writes them to model_list.json
     """
     lab_settings: XnneHangLabSettings = load_settings_file("lab.toml", XnneHangLabSettings)
+    root_setting: RootAbsDir = lab_settings.root
     s = lab_settings.agent.llm
 
     providers: dict[str, tuple[str, str]] = {
@@ -75,7 +76,7 @@ def main() -> None:
         logger.warning("api_key 不正确可能会导致获取模型列表失败")
 
     # 需要完整列表就写到文件（或直接 print(model_map)）
-    with Path("model_list.json").open("w", encoding="utf-8") as f:
+    with (Path(root_setting.root_dir) / "model_list.json").open("w", encoding="utf-8") as f:
         json.dump(model_map, f, ensure_ascii=False, indent=2)
 
 

--- a/scripts/list_model_name.py
+++ b/scripts/list_model_name.py
@@ -2,55 +2,46 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
 
 import requests
 from loguru import logger
+from pydantic import BaseModel, ValidationError
 
 from lab.config_manager import XnneHangLabSettings, load_settings_file
 
 
-def fetch_model_list(base_url: str, api_key: str|None = None, timeout: float = 10.0) -> list[str]:
-    """
-    Assumes base_url is already a correct OpenAI-compatible prefix, e.g.:
-      https://api.openai.com/v1
-      https://generativelanguage.googleapis.com/v1beta/openai/
-    It will call: GET {base_url.rstrip('/')}/models
+class ModelItem(BaseModel):
+    id: str  # 只关心 id，其它字段自动忽略
 
-    Returns: sorted unique model ids.
-    """
+
+class ModelsResponse(BaseModel):
+    data: list[ModelItem]
+
+
+def fetch_model_list(base_url: str, api_key: str | None = None, timeout: float = 10.0) -> list[str]:
     url = f"{base_url.rstrip('/')}/models"
-    headers = {"Accept": "application/json"}
+    headers: dict[str, str] = {"Accept": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
 
     r = requests.get(url, headers=headers, timeout=timeout)
     if not (200 <= r.status_code < 300):
-        # Many providers return HTML when blocked by Cloudflare; keep it short.
-        snippet = r.text[:300].replace("\n", " ")
+        snippet = r.text[:200].replace("\n", " ")
         raise RuntimeError(f"HTTP {r.status_code} from {url}: {snippet}")
 
-    payload: Any = r.json()
+    try:
+        parsed = ModelsResponse.model_validate(r.json())
+    except ValidationError as e:
+        raise RuntimeError(f"Invalid /models response from {url}: {e}") from e
 
-    # OpenAI-compatible: {"object":"list","data":[{"id":"..."}]}
-    data = payload.get("data") if isinstance(payload, dict) else None  # type: ignore
-    if not isinstance(data, list):
-        raise RuntimeError(
-            f"Unexpected response shape from {url}: top-level keys={list(payload.keys()) if isinstance(payload, dict) else type(payload)}"  # type: ignore
-        )  # type: ignore
-
-    ids: list[str] = []
-    for item in data:  # type: ignore
-        if isinstance(item, dict):
-            mid = item.get("id")  # type: ignore
-            if isinstance(mid, str):
-                ids.append(mid)
-
-    return sorted(set(ids))
+    return sorted({m.id for m in parsed.data})
 
 
 def main() -> None:
-    """列出配置项中填写 api_key 的模型列表"""
+    """logger 列出配置项中填写 api_key 的模型列表,并写入 model_list.json
+    Returns:
+        None. Logs the results and writes them to model_list.json
+    """
     lab_settings: XnneHangLabSettings = load_settings_file("lab.toml", XnneHangLabSettings)
     s = lab_settings.agent.llm
 
@@ -78,7 +69,6 @@ def main() -> None:
     summary = {k: len(v) for k, v in model_map.items()}
     logger.info(f"model counts: {summary}")
     logger.info("仅获取了有 api_key 的模型列表")
-
 
     if errors:
         logger.warning(f"failed: {list(errors.keys())}")

--- a/scripts/list_model_name.py
+++ b/scripts/list_model_name.py
@@ -79,6 +79,11 @@ def main() -> None:
     logger.info(f"model counts: {summary}")
     logger.info("仅获取了有 api_key 的模型列表")
 
+
+    if errors:
+        logger.warning(f"failed: {list(errors.keys())}")
+        logger.warning("api_key 不正确可能会导致获取模型列表失败")
+
     # 需要完整列表就写到文件（或直接 print(model_map)）
     with Path("model_list.json").open("w", encoding="utf-8") as f:
         json.dump(model_map, f, ensure_ascii=False, indent=2)

--- a/scripts/list_model_name.py
+++ b/scripts/list_model_name.py
@@ -25,9 +25,12 @@ def fetch_model_list(base_url: str, api_key: str | None = None, timeout: float =
         headers["Authorization"] = f"Bearer {api_key}"
 
     r = requests.get(url, headers=headers, timeout=timeout)
-    if not (200 <= r.status_code < 300):
-        snippet = r.text[:200].replace("\n", " ")
-        raise RuntimeError(f"HTTP {r.status_code} from {url}: {snippet}")
+    try:
+        r.raise_for_status()
+    except requests.HTTPError as exc:
+        # Many providers return HTML when blocked by Cloudflare; keep it short.
+        snippet = r.text[:300].replace("\n", " ")
+        raise RuntimeError(f"HTTP {r.status_code} from {url}: {snippet}") from exc
 
     try:
         parsed = ModelsResponse.model_validate(r.json())
@@ -62,8 +65,18 @@ def main() -> None:
             continue
         try:
             model_map[name] = fetch_model_list(base_url, api_key=api_key)
+        except requests.exceptions.RequestException as e:
+            logger.exception(f"Request error while fetching models for provider '{name}'")
+            errors[name] = f"Request failed ({type(e).__name__}): {e}"
+        except json.JSONDecodeError as e:
+            logger.exception(f"JSON decode error while fetching models for provider '{name}'")
+            errors[name] = f"JSON decode failed ({type(e).__name__}): {e}"
+        except RuntimeError as e:
+            logger.exception(f"Runtime error while fetching models for provider '{name}'")
+            errors[name] = f"Runtime error ({type(e).__name__}): {e}"
         except Exception as e:
-            errors[name] = str(e)
+            logger.exception(f"Unexpected error while fetching models for provider '{name}'")
+            errors[name] = f"Unexpected error ({type(e).__name__}): {e}"
 
     for k, v in model_map.items():
         logger.info(f"{k}: {v}")


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->
[Learn Alma：Tool Model 和 Chat Model 的分离，以及 Web Fetch 和 Web Search 的编排](https://xnnehang.top/posts/default/learn_alma_part1)

为了拆分 Tool Model 和 Chat Model 有必要改变一下 config 的结构，将 model_name 从 provider 中移除，改为手动填写。

那么 list_model_name 就是必要的。

## 解决方案

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

如果填写了 provider 对应的 api_key，就会尝试 fetch_model_name，以 logger 的形式返回， api_key 错误会导致 fetch failed。

并且会将成功  fetch 的 model 写入 `model_list.json`，但缓存机制未做。不想搞得太复杂。如果我的 provider 超出 10 个的时候，我会做缓存。

key right
```shell
2026-01-27 10:15:48.337 | INFO     | __main__:main:77 - cerebras: ['gpt-oss-120b', 'llama-3.3-70b', 'llama3.1-8b', 'qwen-3-235b-a22b-instruct-2507', 'qwen-3-32b', 'zai-glm-4.7']
2026-01-27 10:15:48.337 | INFO     | __main__:main:77 - oaipro: ['babbage-002', 'chatgpt-4o-latest', 'claude-2.0', 'claude-2.1', 'claude-3-5-haiku-20241022', 'claude-3-5-sonnet-20240620', 'claude-3-5-sonnet-20241022', 'claude-3-7-sonnet-20250219', 'claude-3-7-sonnet-20250219-thinking', 'claude-3-haiku-20240307', 'claude-3-opus-20240229', 'claude-3-sonnet-20240229', 'claude-haiku-4-5-20251001', 'claude-opus-4-1-20250805', 'claude-opus-4-20250514', 'claude-opus-4-5-20251101', 'claude-sonnet-4-20250514', 'claude-sonnet-4-5-20250929', 'dall-e-2', 'dall-e-3', 'davinci-002', 'gpt-3.5-turbo', 'gpt-3.5-turbo-0125', 'gpt-3.5-turbo-1106', 'gpt-3.5-turbo-16k', 'gpt-3.5-turbo-instruct', 'gpt-3.5-turbo-instruct-0914', 'gpt-4', 'gpt-4-0125-preview', 'gpt-4-0613', 'gpt-4-1106-preview', 'gpt-4-turbo', 'gpt-4-turbo-2024-04-09', 'gpt-4-turbo-preview', 'gpt-4.1', 'gpt-4.1-2025-04-14', 'gpt-4.1-mini', 'gpt-4.1-mini-2025-04-14', 'gpt-4.1-nano', 'gpt-4.1-nano-2025-04-14', 'gpt-4.5-preview', 'gpt-4.5-preview-2025-02-27', 'gpt-4o', 'gpt-4o-2024-05-13', 'gpt-4o-2024-08-06', 'gpt-4o-2024-11-20', 'gpt-4o-mini', 'gpt-4o-mini-2024-07-18', 'gpt-5', 'gpt-5-2025-08-07', 'gpt-5-chat-latest', 'gpt-5-mini', 'gpt-5-mini-2025-08-07', 'gpt-5-nano', 'gpt-5-nano-2025-08-07', 'gpt-5.1', 'gpt-5.1-2025-11-13', 'gpt-5.1-chat-latest', 'gpt-5.2', 'gpt-5.2-2025-12-11', 'gpt-5.2-chat-latest', 'o1', 'o1-2024-12-17', 'o1-mini', 'o1-mini-2024-09-12', 'o1-preview', 'o1-preview-2024-09-12', 'o3', 'o3-2025-04-16', 'o3-mini', 'o3-mini-2025-01-31', 'o4-mini', 'o4-mini-2025-04-16', 'omni-moderation-2024-09-26', 'omni-moderation-latest', 'text-embedding-3-large', 'text-embedding-3-small', 'text-embedding-ada-002', 'text-moderation-007', 'text-moderation-latest', 'text-moderation-stable', 'tts-1', 'tts-1-1106', 'tts-1-hd', 'tts-1-hd-1106', 'whisper-1']
2026-01-27 10:15:48.337 | INFO     | __main__:main:79 - model counts: {'cerebras': 6, 'oaipro': 86}
2026-01-27 10:15:48.337 | INFO     | __main__:main:80 - 仅获取了有 api_key 的模型列表
```
key error
```shell
PS D:\tmp\XnneHangLab> just list-model   
uv run scripts/list_model_name.py
2026-01-27 10:43:11.568 | ERROR    | __main__:main:75 - Runtime error while fetching models for provider 'oaipro'
Traceback (most recent call last):

  File "D:\tmp\XnneHangLab\scripts\list_model_name.py", line 29, in fetch_model_list
    r.raise_for_status()
    │ └ <function Response.raise_for_status at 0x00000238624F5800>
    └ <Response [401]>

  File "D:\tmp\XnneHangLab\.venv\Lib\site-packages\requests\models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
          │         │                        └ <Response [401]>
          │         └ '401 Client Error: Unauthorized for url: https://api.oaipro.com/v1/models'
          └ <class 'requests.exceptions.HTTPError'>

requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://api.oaipro.com/v1/models


The above exception was the direct cause of the following exception:


Traceback (most recent call last):

  File "D:\tmp\XnneHangLab\scripts\list_model_name.py", line 97, in <module>
    main()
    └ <function main at 0x00000238630FB4C0>

> File "D:\tmp\XnneHangLab\scripts\list_model_name.py", line 67, in main
    model_map[name] = fetch_model_list(base_url, api_key=api_key)
    │         │       │                │                 └ 'sk-BFRTZhdxZjsS6e87c3Avm77CRhUw3j1V25jUsJd52y41HJcvHW'
    │         │       │                └ 'https://api.oaipro.com/v1'
    │         │       └ <function fetch_model_list at 0x000002385FD0D300>
    │         └ 'oaipro'
    └ {'cerebras': ['gpt-oss-120b', 'llama-3.3-70b', 'llama3.1-8b', 'qwen-3-235b-a22b-instruct-2507', 'qwen-3-32b', 'zai-glm-4.7']}

  File "D:\tmp\XnneHangLab\scripts\list_model_name.py", line 33, in fetch_model_list
    raise RuntimeError(f"HTTP {r.status_code} from {url}: {snippet}") from exc

RuntimeError: HTTP 401 from https://api.oaipro.com/v1/models: {"error":{"message":"无效的令牌 (request id: 0f4907d6-c7ad-438b-9ada-cf431f1adec7)","type":"new_api_error"}}
2026-01-27 10:43:11.570 | INFO     | __main__:main:82 - cerebras: ['gpt-oss-120b', 'llama-3.3-70b', 'llama3.1-8b', 'qwen-3-235b-a22b-instruct-2507', 'qwen-3-32b', 'zai-glm-4.7']
2026-01-27 10:43:11.570 | INFO     | __main__:main:84 - model counts: {'cerebras': 6}
2026-01-27 10:43:11.570 | INFO     | __main__:main:85 - 仅获取了有 api_key 的模型列表
2026-01-27 10:43:11.570 | WARNING  | __main__:main:88 - failed: ['oaipro']
2026-01-27 10:43:11.570 | WARNING  | __main__:main:89 - api_key 不正确可能会导致获取模型列表失败
```

已知返回类型和结构的时候用 pydantic 收束 unkown 会比用 object 好很多。

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [x] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
