### PR TITLE
fix(memory_agent): restore upload image handling when no tool image present

### DIFF
--- a/src/lab/agent/agents/memory_agent/agent.py
+++ b/src/lab/agent/agents/memory_agent/agent.py
@@ -181,22 +181,18 @@ class MemoryAgent(AgentInterface):
                 warn = "注意：当前 chat_model 不支持图像输入，且未配置可用的 vision_model，无法读取图片内容。\n\n"
                 full_prompt = warn + base_prompt
             else:
-                if tool_result.tool_image:
-                    summaries = await self.vision.summarize_all(
-                        user_input_text=user_input_text,
-                        tool_image=tool_result.tool_image,
-                        upload_images=user_up_images,
-                        require_detailed=self.require_detailed,
-                    )
-                    full_prompt = self.prompt.build_prompt_with_image_summaries(
-                        user_input_text=user_input_text,
-                        tools_summary_str=tool_result.trace_json if self.enable_tool else "(无)",
-                        tool_image_summary=summaries.tool_image_summary,
-                        user_image_summary=self.prompt.format_labeled_summaries(summaries.upload_summaries),
-                    )
-                else:
-                    warn = "注意：当前 chat_model 不支持图像输入，且本次没有工具回调图片，无法读取图片内容。\n\n"
-                    full_prompt = warn + base_prompt
+                summaries = await self.vision.summarize_all(
+                    user_input_text=user_input_text,
+                    tool_image=tool_result.tool_image,
+                    upload_images=user_up_images,
+                    require_detailed=self.require_detailed,
+                )
+                full_prompt = self.prompt.build_prompt_with_image_summaries(
+                    user_input_text=user_input_text,
+                    tools_summary_str=tool_result.trace_json if self.enable_tool else "(无)",
+                    tool_image_summary=summaries.tool_image_summary,
+                    user_image_summary=self.prompt.format_labeled_summaries(summaries.upload_summaries),
+                )
 
             send_msg = OpenAIMessage(role="user", content=full_prompt)
             final_messages = [*messages_wo_user, send_msg]

--- a/src/lab/agent/agents/memory_agent/vision_summarizer.py
+++ b/src/lab/agent/agents/memory_agent/vision_summarizer.py
@@ -97,7 +97,7 @@ class VisionSummarizer:
         self,
         *,
         user_input_text: str,
-        tool_image: ImagePayload,
+        tool_image: ImagePayload | None,
     ) -> str:
         """tool 回调图默认单张：返回其 summary（或 ""）。"""
         if not tool_image or not self.vision_llm:
@@ -139,7 +139,7 @@ class VisionSummarizer:
         self,
         *,
         user_input_text: str,
-        tool_image: ImagePayload,
+        tool_image: ImagePayload | None,
         upload_images: list[tuple[str, str]],
         require_detailed: bool,
     ) -> VisionSummaryResult:


### PR DESCRIPTION
### Motivation
- Restore original behavior from `memory_agent_stay_copy.py` so user-uploaded images are summarized even when there is no tool callback image. 
- Fix a regression introduced during the refactor where the non-vision-chat branch skipped upload-image summaries unless a tool image existed. 

### Description
- In `memory_agent/agent.py` the non-vision-chat branch now always calls `self.vision.summarize_all(...)` when `vision_llm` is available, instead of only doing so when a tool image exists. 
- Updated `VisionSummarizer` in `vision_summarizer.py` to accept `tool_image: ImagePayload | None` for `summarize_tool_image` and `summarize_all`, and ensured internal handling is safe when `tool_image` is None. 
- Kept prompt building logic unchanged but ensured `user_image_summary` is populated from upload-image summaries in the corrected branch. 

### Testing
- Ran `python -m compileall src/lab/agent/agents/memory_agent/agent.py src/lab/agent/agents/memory_agent/vision_summarizer.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984721783a083339d3fb2a03f5d8f7e)