### PR TITLE
:bug: fix(memory_agent): prevent stack overflow by fixing recursive chat() override.

### DIFF
--- a/docs/architecture/memory_agent.md
+++ b/docs/architecture/memory_agent.md
@@ -1,69 +1,69 @@
-    # MemoryAgent 架构说明
+# MemoryAgent 架构说明
 
-    本文描述 `MemoryAgent` 的模块分层、数据流与关键决策，面向工程维护与架构理解。
+本文描述 `MemoryAgent` 的模块分层、数据流与关键决策，面向工程维护与架构理解。
 
-    ## 模块分层
+## 模块分层
 
-    ```mermaid
-    flowchart LR
-      A[MemoryAgent(agent.py)
+```mermaid
+flowchart LR
+A[MemoryAgent(agent.py)
 Orchestrator] --> B[ToolRunner
 (tool_runner.py)]
-      A --> C[VisionSummarizer
+A --> C[VisionSummarizer
 (vision_summarizer.py)]
-      A --> D[PromptBuilder
+A --> D[PromptBuilder
 (prompt_builder.py)]
-      A --> E[MessageFactory
+A --> E[MessageFactory
 (message_factory.py)]
-      A --> F[MemoryStore
+A --> F[MemoryStore
 (memory_store.py)]
-    ```
+```
 
-    - **MemoryAgent（编排器）**：只负责“决策树”与组件调用，避免拼接/解析细节膨胀。
-    - **ToolRunner**：运行 MCP tool loop，返回 tool trace JSON + tool 回调图（默认单张 `tool1`）。
-    - **VisionSummarizer**：对 tool 图与 upload 图生成 summaries，支持：
-      - 快模式（一次多图 1 次调用）
-      - 细模式（逐图并发 N 次调用，带并发上限）
-    - **PromptBuilder**：纯文本 prompt 拼装（base / summaries）。
-    - **MessageFactory**：OpenAIMessage 解析与构造（带标签多图）。
-    - **MemoryStore**：memory + history + interrupt（不存 base64）。
+- **MemoryAgent（编排器）**：只负责“决策树”与组件调用，避免拼接/解析细节膨胀。
+- **ToolRunner**：运行 MCP tool loop，返回 tool trace JSON + tool 回调图（默认单张 `tool1`）。
+- **VisionSummarizer**：对 tool 图与 upload 图生成 summaries，支持：
+- 快模式（一次多图 1 次调用）
+- 细模式（逐图并发 N 次调用，带并发上限）
+- **PromptBuilder**：纯文本 prompt 拼装（base / summaries）。
+- **MessageFactory**：OpenAIMessage 解析与构造（带标签多图）。
+- **MemoryStore**：memory + history + interrupt（不存 base64）。
 
-    ## 决策树（核心逻辑）
+## 决策树（核心逻辑）
 
-    维度：
-    - `enable_tool`
-    - `chat_supports_vision`
-    - `require_detailed`
+维度：
+- `enable_tool`
+- `chat_supports_vision`
+- `require_detailed`
 
-    ### 关键规则
+### 关键规则
 
-    1. **最终回答由 chat_model 输出**（streaming）；vision_model 仅用于摘要预处理。
-    2. **history 不存 base64**：即使发送给 chat 的 message 带图片，写入 history 的只存文本 prompt。
-    3. **tool 图与 upload 图隔离**：tool 图默认单张，不混入 upload 的 p1/p2 标签。
+1. **最终回答由 chat_model 输出**（streaming）；vision_model 仅用于摘要预处理。
+2. **history 不存 base64**：即使发送给 chat 的 message 带图片，写入 history 的只存文本 prompt。
+3. **tool 图与 upload 图隔离**：tool 图默认单张，不混入 upload 的 p1/p2 标签。
 
-    ### 行为矩阵
+### 行为矩阵
 
-    | chat_supports_vision | require_detailed | 行为 |
-    |---|---|---|
-    | False | False | vision 一次多图 → 得到 p1/p2... summaries → 纯文本喂给 chat |
-    | False | True  | vision 逐图并发 → 得到 p1/p2... summaries → 纯文本喂给 chat |
-    | True  | False | 不生成 summaries；图片直接喂给 chat（带标签） |
-    | True  | True  | 生成逐图 summaries + 图片一并喂给 chat（图+摘要双保险） |
+| chat_supports_vision | require_detailed | 行为 |
+|---|---|---|
+| False | False | vision 一次多图 → 得到 p1/p2... summaries → 纯文本喂给 chat |
+| False | True  | vision 逐图并发 → 得到 p1/p2... summaries → 纯文本喂给 chat |
+| True  | False | 不生成 summaries；图片直接喂给 chat（带标签） |
+| True  | True  | 生成逐图 summaries + 图片一并喂给 chat（图+摘要双保险） |
 
-    `enable_tool=True` 时，先追加 tool loop 的 trace JSON，并可额外对 tool 图生成 tool summary。
+`enable_tool=True` 时，先追加 tool loop 的 trace JSON，并可额外对 tool 图生成 tool summary。
 
-    ## 性能与成本
+## 性能与成本
 
-    - 并发（Semaphore + gather）主要降低 **墙钟时间**，不降低 token 成本。
-    - `max_vision_concurrency` 是 in-flight vision 请求上限，用于防止限流与拥塞。
-    - 快模式（一次多图）在成本与等待时间上更优，但细节/一致性可能不如逐图。
+- 并发（Semaphore + gather）主要降低 **墙钟时间**，不降低 token 成本。
+- `max_vision_concurrency` 是 in-flight vision 请求上限，用于防止限流与拥塞。
+- 快模式（一次多图）在成本与等待时间上更优，但细节/一致性可能不如逐图。
 
-    ## 失败策略（推荐）
+## 失败策略（推荐）
 
-    - 逐图并发时：某张失败应返回占位（例如 `[ERROR] p2 摘要失败: ...`），避免 silent drop 导致下游对齐失败。
-    - 解析失败：降级为 `p_all`（或 `p_all`）保底，确保链路不中断。
+- 逐图并发时：某张失败应返回占位（例如 `[ERROR] p2 摘要失败: ...`），避免 silent drop 导致下游对齐失败。
+- 解析失败：降级为 `p_all`（或 `p_all`）保底，确保链路不中断。
 
-    ## 扩展点
+## 扩展点
 
-    - tool 多图：在 `ToolRunner` 改为收集 image_refs 列表，并给出 tool1/tool2... summaries。
-    - 支持 http(s) 图片：在 `MessageFactory.extract_text_and_data_images` 扩展。
+- tool 多图：在 `ToolRunner` 改为收集 image_refs 列表，并给出 tool1/tool2... summaries。
+- 支持 http(s) 图片：在 `MessageFactory.extract_text_and_data_images` 扩展。

--- a/src/lab/agent/agents/memory_agent/agent.py
+++ b/src/lab/agent/agents/memory_agent/agent.py
@@ -107,8 +107,9 @@ class MemoryAgent(AgentInterface):
         self.segment_method = segment_method
 
         # bind chat pipeline
-        self.chat = self._chat_function_factory(self._stream_chat_tokens)  # type: ignore[method-assign]
-
+        self._bound_chat: Callable[[BatchInput], AsyncIterator[SentenceOutput | AudioOutput]] = (
+            self._chat_function_factory(self._stream_chat_tokens)
+        )
         logger.info(f"MemoryAgent initialized. enable_tool={self.enable_tool}")
 
     # ---------------------------------------------------------------------
@@ -283,5 +284,6 @@ class MemoryAgent(AgentInterface):
 
         return chat_with_memory
 
-    async def chat(self, input_data: BatchInput) -> AsyncIterator[str | AudioOutput]:  # type: ignore[override]
-        return self.chat(input_data)  # type: ignore[return-value]
+    async def chat(self, input_data: BatchInput) -> AsyncIterator[SentenceOutput | AudioOutput]:  # type: ignore[override]
+        async for chunk in self._bound_chat(input_data):
+            yield chunk


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机
- #89  .part2
1. `self.chat` 可能会引起无限递归。 
在拆分 `memory_agent/` 结构后，`MemoryAgent.chat()` 仍保留了旧的占位实现：
`return self.chat(input_data)`
这会在 任何上层以“方法调用”方式触发 `MemoryAgent.chat()` override 的场景下造成无限递归。
2.  修复文档中的意外缩进。

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->

## 解决方案

- 移除/修正 `chat()` 的递归调用，改为转发到初始化时绑定的管线函数（由 `_chat_function_factory` 构造）。
- `chat()` 以 async generator 形式 `async for ...: yield ...` 转发，保证返回类型为 `AsyncIterator[...]`，同时避免 Pylance 的 `Coroutine -> AsyncIterator` 类型报错。
- 行为保持不变：仍然经过既有的 transformer pipeline（tts_filter / display_processor / actions_extractor / sentence_divider）。


<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [x] :bug: fix: 修复 bug
-  [x] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
