### PR TITLE
fix: skip tool loop when no MCP tools available

### DIFF
--- a/src/lab/agent/agents/memory_agent/tool_runner.py
+++ b/src/lab/agent/agents/memory_agent/tool_runner.py
@@ -84,6 +84,12 @@ class ToolRunner:
         if not enable_tool:
             return ToolRunResult(trace_json="(无)", tool_image=None, tool_trace=[])
 
+        # 兼容场景：enable_tool=true 但 MCP 未连接成功（或无可用工具）时，
+        # 退化为普通对话模式，不进入 tool loop。
+        if not available_tools:
+            logger.info("[TOOL] enable_tool=True but no available tools; skip tool loop.")
+            return ToolRunResult(trace_json="(无)", tool_image=None, tool_trace=[])
+
         _, tool_trace = await self.tool_loop.run_tool_loop(
             tool_system_prompt=tool_system_prompt,
             available_tools=available_tools,


### PR DESCRIPTION
### Motivation
- When `enable_mcp=true` but MCP servers are not connected, the agent previously attempted a tool call and triggered OpenAI 400 errors like `tool_choice is only allowed when tools are specified`; the intent is to continue normal chat in that case.


> 感觉 vibe coding 的小 PR 得给它 collect 起来再 PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ab361aa2883338dba014571b8a0e2)